### PR TITLE
meson: revamp options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,13 +34,8 @@ jobs:
             pkg-config
       - uses: actions/checkout@v4
       - run: |
-          meson setup \
-            -Db_sanitize=address \
-            -Dbuild_tests=true \
-            -Dbuild_examples=true \
-            -Dwith_yaml=true \
-            -Dwith_editline=true \
-            -Dbuild_doc=true \
-            build
+          meson setup build \
+            --auto-features=enabled \
+            -Db_sanitize=address
       - run: ninja -C build
       - run: build/test/ecoli-test

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -1,11 +1,15 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright 2019, Olivier MATZ <zer0@droids-corp.org>
 
+doxygen = find_program('doxygen', required: get_option('doc'))
+if not doxygen.found()
+  subdir_done()
+endif
+
 cdata = configuration_data()
 cdata.set('VERSION', meson.project_version())
 cdata.set('OUTPUT', meson.current_build_dir())
 cdata.set('TOPDIR', meson.project_source_root())
-doxygen = find_program('doxygen')
 
 man_cdata = configuration_data()
 man_cdata.merge_from(cdata)

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -1,10 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright 2018, Olivier MATZ <zer0@droids-corp.org>
 
-readline_dep = dependency('readline', required: false)
-if readline_dep.found()
-	subdir('readline')
-endif
-if yaml_dep.found() and edit_dep.found()
-	subdir('parse-yaml')
-endif
+subdir('readline')
+subdir('parse-yaml')

--- a/examples/parse-yaml/meson.build
+++ b/examples/parse-yaml/meson.build
@@ -1,6 +1,11 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright 2018, Olivier MATZ <zer0@droids-corp.org>
 
+if not get_option('examples').require(yaml_dep.found() and edit_dep.found(),
+		error_message: 'examples require libyaml and libedit').allowed()
+	subdir_done()
+endif
+
 parse_yaml_sources = files(
 	'parse-yaml.c',
 )

--- a/examples/readline/meson.build
+++ b/examples/readline/meson.build
@@ -1,6 +1,11 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright 2018, Olivier MATZ <zer0@droids-corp.org>
 
+readline_dep = dependency('readline', required: get_option('examples'))
+if not readline_dep.found()
+	subdir_done()
+endif
+
 readline_sources = files(
 	'main.c',
 )

--- a/include/meson.build
+++ b/include/meson.build
@@ -7,7 +7,6 @@ libecoli_headers = files(
 	'ecoli_complete.h',
 	'ecoli_config.h',
 	'ecoli_dict.h',
-	'ecoli_editline.h',
 	'ecoli_init.h',
 	'ecoli_htable.h',
 	'ecoli_log.h',
@@ -42,6 +41,17 @@ libecoli_headers = files(
 	'ecoli_test.h',
 	'ecoli_utils.h',
 	'ecoli_vec.h',
-	'ecoli_yaml.h',
 )
+
+if edit_dep.found()
+	libecoli_headers += files(
+		'ecoli_editline.h',
+	)
+endif
+if yaml_dep.found()
+	libecoli_headers += files(
+		'ecoli_yaml.h',
+	)
+endif
+
 install_headers(libecoli_headers)

--- a/meson.build
+++ b/meson.build
@@ -11,12 +11,12 @@ project('libecoli',
 		'c_std=c99',
 	])
 
-edit_dep = dependency('libedit', required: get_option('with_editline'))
-yaml_dep = dependency('yaml-0.1', required: get_option('with_yaml'))
+edit_dep = dependency('libedit', required: get_option('editline'))
+yaml_dep = dependency('yaml-0.1', required: get_option('yaml'))
 
 add_project_arguments('-Wmissing-prototypes', language : 'c')
 add_project_arguments('-D_GNU_SOURCE', language : 'c')
-if get_option('build_tests')
+if get_option('tests').allowed()
 	add_project_arguments('--coverage', language : 'c')
 	add_project_link_arguments('--coverage' , language: 'c')
 endif
@@ -53,12 +53,6 @@ else
 		description : 'Extensible COmmand LIne library.')
 endif
 
-if get_option('build_tests')
-	subdir('test')
-endif
-if get_option('build_examples')
-	subdir('examples')
-endif
-if get_option('build_doc')
-	subdir('doc')
-endif
+subdir('test')
+subdir('examples')
+subdir('doc')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,10 +1,10 @@
-option('with_yaml', type : 'boolean', value : false,
+option('yaml', type : 'feature', value : 'auto',
        description: 'Compile with yaml support using libyaml.')
-option('with_editline', type : 'boolean', value : true,
+option('editline', type : 'feature', value : 'auto',
        description: 'Compile with editline support using libedit.')
-option('build_doc', type : 'boolean', value : false,
+option('doc', type : 'feature', value : 'auto',
        description: 'Generate project documentation.')
-option('build_tests', type : 'boolean', value : false,
+option('tests', type : 'feature', value : 'auto',
        description: 'Build test binaries.')
-option('build_examples', type : 'boolean', value : false,
+option('examples', type : 'feature', value : 'auto',
        description: 'Build examples.')

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,6 +1,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright 2018, Olivier MATZ <zer0@droids-corp.org>
 
+if not get_option('tests').allowed()
+  subdir_done()
+endif
+
 test_sources = files(
 	'test.c',
 )


### PR DESCRIPTION
Change all options to be features. Remove the "with_" and "build_" prefixes which do not bring any value.

By default, everything will be "auto"; meaning "enabled" if the dependencies are found.