### PR TITLE
htable: add function to force a stable seed

### DIFF
--- a/include/ecoli/htable.h
+++ b/include/ecoli/htable.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <stdio.h>
+#include <stdint.h>
 #include <stdbool.h>
 
 typedef void (*ec_htable_elt_free_t)(void *);
@@ -127,6 +128,16 @@ size_t ec_htable_len(const struct ec_htable *htable);
  *   The duplicated hash table, or NULL on error (errno is set).
  */
 struct ec_htable *ec_htable_dup(const struct ec_htable *htable);
+
+/**
+ * Force a seed for the hash function.
+ * This function must be called *before* ec_init().
+ * By default, a random value is determined during ec_init().
+ *
+ * @param seed
+ *   The seed value.
+ */
+void ec_htable_force_seed(uint32_t seed);
 
 /**
  * Dump a hash table.

--- a/src/htable.c
+++ b/src/htable.c
@@ -22,6 +22,7 @@
 
 EC_LOG_TYPE_REGISTER(htable);
 
+static bool seed_forced;
 static uint32_t ec_htable_seed;
 
 struct ec_htable *ec_htable(void)
@@ -330,12 +331,19 @@ fail:
 	return NULL;
 }
 
+void ec_htable_force_seed(uint32_t seed)
+{
+	ec_htable_seed = seed;
+	seed_forced = true;
+}
+
 static int ec_htable_init_func(void)
 {
 	int fd;
 	ssize_t ret;
 
-	return 0;//XXX for test reproduceability
+	if (seed_forced)
+		return 0;
 
 	fd = open("/dev/urandom", 0);
 	if (fd == -1) {

--- a/test/test.h
+++ b/test/test.h
@@ -17,6 +17,7 @@
 #define EC_TEST_MAIN()							\
 	EC_LOG_TYPE_REGISTER(__file__);					\
 	static void __attribute__((constructor, used)) __init(void) {	\
+		ec_htable_force_seed(42);				\
 		ec_init();						\
 	}								\
 	static void __attribute__((destructor, used)) __exit(void) {	\


### PR DESCRIPTION

For unit tests, force a stable seed. Otherwise, use a random value.
