### PR TITLE
doxygen: fix empty documentation

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -4,11 +4,12 @@
 PROJECT_NAME           = "Libecoli"
 PROJECT_BRIEF          = "Extensible COmmand LIne library"
 PROJECT_NUMBER         = @VERSION@
-INPUT                  = @TOPDIR@/include
+INPUT                  = @TOPDIR@/include @TOPDIR@/include/ecoli
 OUTPUT_DIRECTORY       = @OUTPUT@
-FILE_PATTERNS          = ecoli*.h
+FILE_PATTERNS          = *.h
 
-EXCLUDE_SYMBOLS        = __* TAILQ_* free* init* realloc malloc boolean complete desc dict u64 test type size string subschema parse node name list key i64 help set_config schema priority exit get_child get_children_count eval_* @1
+EXCLUDE_SYMBOLS        = __* TAILQ_* free* init* realloc malloc boolean complete desc dict u64 test type size string subschema parse node name list key i64 help set_config schema priority exit get_child get_children_count eval_* @1* @3* lstat opendir readdir closedir dirfd fstatat
+
 
 OPTIMIZE_OUTPUT_FOR_C   = YES
 ENABLE_PREPROCESSING    = YES

--- a/include/ecoli/complete.h
+++ b/include/ecoli/complete.h
@@ -21,8 +21,6 @@
  * lists the possible completions. The completions are grouped into
  * ec_comp_group. All completions items of a group shares the same parsing
  * state and are issued by the same node.
- *
- * @}
  */
 
 #pragma once
@@ -508,3 +506,5 @@ struct ec_comp_item *ec_comp_iter_next(struct ec_comp_item *item, enum ec_comp_t
 #define EC_COMP_FOREACH(item, comp, type)                                                          \
 	for (item = ec_comp_iter_first(comp, type); item != NULL;                                  \
 	     item = ec_comp_iter_next(item, type))
+
+/** @} */

--- a/include/ecoli/editline.h
+++ b/include/ecoli/editline.h
@@ -4,6 +4,7 @@
 
 /**
  * @defgroup ecoli_editline Editline
+ * @{
  *
  * @brief Helpers for editline
  *
@@ -486,3 +487,5 @@ int ec_editline_set_help(struct ec_node *node, const char *help);
  *   0 on success, or -1 on error.
  */
 int ec_editline_set_callback(struct ec_node *node, ec_editline_command_cb_t cb);
+
+/** @} */


### PR DESCRIPTION

The headers have been moved/renamed. The generated documentation is empty.

Fix Doxyfile.in.
