### PR TITLE
examples: fix missing dependency to libedit

### DIFF
--- a/examples/extension-editline/meson.build
+++ b/examples/extension-editline/meson.build
@@ -10,4 +10,5 @@ ecoli_extension_editline = executable(
 	'ecoli-extension-editline',
 	extension_editline_sources,
 	include_directories : inc,
-	link_with : libecoli)
+	link_with : libecoli,
+	dependencies: [edit_dep])

--- a/examples/pool-editline/meson.build
+++ b/examples/pool-editline/meson.build
@@ -10,4 +10,5 @@ ecoli_pool_editline = executable(
 	'ecoli-pool-editline',
 	pool_editline_sources,
 	include_directories : inc,
-	link_with : libecoli)
+	link_with : libecoli,
+	dependencies: [edit_dep])


### PR DESCRIPTION
These examples cannot compile without libedit, add the missing dependency in meson.build.

Fixes: e601e4162737 ("example: add extension-editline")
Fixes: e7fdbd5c1bbd ("examples: add pool-editline")