### PR TITLE
node: add ec_node_find_next

### DIFF
--- a/include/ecoli/node.h
+++ b/include/ecoli/node.h
@@ -563,6 +563,26 @@ void ec_node_dump(FILE *out, const struct ec_node *node);
 struct ec_node *ec_node_find(struct ec_node *node, const char *id);
 
 /**
+ * Find the next node matching an identifier.
+ *
+ * After a successful call to ec_node_find() or ec_node_find_next(), it is possible to get the next
+ * node that has the specified id. There are 2 options:
+ *
+ * - continue the depth-first search where it was interrupted.
+ * - skip the children of the current node, and continue the depth-first search.
+ *
+ * @param root
+ *   The root of the search, as passed to ec_node_find().
+ * @param prev
+ *   The node returned by the previous search.
+ * @param id
+ *   The node identifier string to match.
+ * @return
+ *   The next node matching the identifier, or NULL if not found.
+ */
+struct ec_node *ec_node_find_next(struct ec_node *root, const struct ec_node *prev, const char *id);
+
+/**
  * Check the type of a node.
  *
  * @param node

--- a/test/node.c
+++ b/test/node.c
@@ -86,6 +86,22 @@ EC_TEST_MAIN()
 	child = ec_node_find(node, "id_dezdex");
 	testres |= EC_TEST_CHECK(child == NULL, "child with wrong id should be NULL");
 
+	/* Test ec_node_find_next */
+	child = ec_node_find_next(node, NULL, "id_x");
+	testres |= EC_TEST_CHECK(
+		child != NULL && !strcmp(ec_node_id(child), "id_x"),
+		"ec_node_find_next should find id_x"
+	);
+
+	child = ec_node_find_next(node, child, "id_y");
+	testres |= EC_TEST_CHECK(
+		child != NULL && !strcmp(ec_node_id(child), "id_y"),
+		"ec_node_find_next should find id_y after id_x"
+	);
+
+	child = ec_node_find_next(node, child, "id_x");
+	testres |= EC_TEST_CHECK(child == NULL, "ec_node_find_next should not find id_x again");
+
 	ret = ec_dict_set(ec_node_attrs(node), "key", "val", NULL);
 	testres |= EC_TEST_CHECK(ret == 0, "cannot set node attribute\n");
 


### PR DESCRIPTION

Similar to ec_pnode_find_next, add a new helper to traverse all nodes.

Signed-off-by: Christophe Fontaine <cfontain@redhat.com>
