### PR TITLE
node_file: fix -Werror=discarded-qualifiers with glibc 2.42.9000

### DIFF
--- a/src/node_file.c
+++ b/src/node_file.c
@@ -68,7 +68,7 @@ static int ec_node_file_parse(
  */
 static int split_path(const char *path, char **dname_p, char **bname_p)
 {
-	char *last_slash;
+	const char *last_slash;
 	size_t dirlen;
 	char *dname, *bname;
 


### PR DESCRIPTION
Glibc 2.42 introduced const-correct overloads for string functions like strchr(), strrchr(), strstr(), etc.

This causes a warning on build:

    src/node_file.c: In function ‘split_path’:
    src/node_file.c:78:20: error: assignment discards ‘const’ qualifier from
    pointer target type [-Werror=discarded-qualifiers]
       78 |         last_slash = strrchr(path, '/');
          |                    ^

Change the variable type to const. We don't need to modify it anyway.

Link: https://sourceware.org/git/?p=glibc.git;a=commitdiff;h=cd748a63ab1a