### PR TITLE
tools: add a tool to generate schema api doc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,11 @@ format:
 	@echo '[clang-format]'
 	$Q $(c_src) | $(CLANG_FORMAT) --files=/proc/self/fd/0 -i --verbose
 
+.PHONY: node-schema
+node-schema: build
+	@echo '[node-schema]'
+	$Q $(BUILDDIR)/tools/gen-node-schema/ecoli-gen-node-schema > doc/node-schema.md
+
 REVISION_RANGE ?= @{u}..
 
 .PHONY: check-commits
@@ -122,6 +127,7 @@ help:
 	$Q echo '  clean         Clean build directory'
 	$Q echo '  tag-release   Create a release commit and signed tag'
 	$Q echo '  tests         Run unit tests'
+	$Q echo '  node-schema   Generate and update node schema API doc'
 	$Q echo '  coverage      Run unit tests and generate test coverage report'
 	$Q echo
 	$Q echo 'Environment variables:'

--- a/doc/node-schema.md
+++ b/doc/node-schema.md
@@ -1,0 +1,236 @@
+# Node schemas
+
+This page lists all grammar node types supported by libecoli. For each node,
+it shows its generic configuration schema, if supported.
+
+## subset
+
+No generic schema.
+
+## str
+
+```
+schema str {
+    string string  {
+        description "The string to match.";
+    }
+}
+```
+
+## space
+
+No generic schema.
+
+## sh_lex
+
+No generic schema.
+
+## seq
+
+```
+schema seq {
+    list children  {
+        description "The list of children nodes, to be parsed in sequence.";
+
+        node  {
+            description "A child node which is part of the sequence.";
+        }
+    }
+}
+```
+
+## re_lex
+
+```
+schema re_lex {
+    list patterns  {
+        description "The list of patterns elements.";
+
+        dict  {
+            description "A pattern element.";
+
+            string pattern  {
+                description "The pattern to match.";
+            }
+            bool keep  {
+                description "Whether to keep or drop the string matching the regular expression.";
+            }
+            string attr  {
+                description "The optional attribute name to attach.";
+            }
+        }
+    }
+    node child  {
+        description "The child node.";
+    }
+}
+```
+
+## re
+
+```
+schema re {
+    string pattern  {
+        description "The pattern to match.";
+    }
+}
+```
+
+## or
+
+```
+schema or {
+    list children  {
+        description "The list of children nodes defining the choice elements.";
+
+        node  {
+            description "A child node which is part of the choice.";
+        }
+    }
+}
+```
+
+## option
+
+```
+schema option {
+    node child  {
+        description "The child node.";
+    }
+}
+```
+
+## once
+
+```
+schema once {
+    node child  {
+        description "The child node.";
+    }
+}
+```
+
+## none
+
+No generic schema.
+
+## many
+
+```
+schema many {
+    node child  {
+        description "The child node.";
+    }
+    uint64 min  {
+        description "The minimum number of matches (default = 0).";
+    }
+    uint64 max  {
+        description "The maximum number of matches. If 0, there is no maximum (default = 0).";
+    }
+}
+```
+
+## uint
+
+```
+schema uint {
+    uint64 min  {
+        description "The minimum valid value (included).";
+    }
+    uint64 max  {
+        description "The maximum valid value (included).";
+    }
+    uint64 base  {
+        description "The base to use. If unset or 0, try to guess.";
+    }
+}
+```
+
+## int
+
+```
+schema int {
+    int64 min  {
+        description "The minimum valid value (included).";
+    }
+    int64 max  {
+        description "The maximum valid value (included).";
+    }
+    uint64 base  {
+        description "The base to use. If unset or 0, try to guess.";
+    }
+}
+```
+
+## file
+
+No generic schema.
+
+## expr
+
+No generic schema.
+
+## empty
+
+No generic schema.
+
+## dynlist
+
+No generic schema.
+
+## dynamic
+
+No generic schema.
+
+## cond
+
+```
+schema cond {
+    string expr  {
+        description "XXX";
+    }
+    node child  {
+        description "The child node.";
+    }
+}
+```
+
+## cmd
+
+```
+schema cmd {
+    string expr  {
+        description "The expression to match. Supported operators are or '|', list ',', many '+',
+                    many-or-zero '*', option '[]', group '()'. An identifier (alphanumeric) can
+                    reference a node whose node_id matches. Else it is interpreted as ec_node_str()
+                    matching this string. Example: command [option] (subset1, subset2) x|y";
+    }
+    list children  {
+        description "The list of children nodes.";
+
+        node  {
+            description "A child node whose id is referenced in the expression.";
+        }
+    }
+}
+```
+
+## bypass
+
+```
+schema bypass {
+    node child  {
+        description "The child node.";
+    }
+}
+```
+
+## any
+
+```
+schema any {
+    string attr  {
+        description "The optional attribute name to attach.";
+    }
+}
+```

--- a/meson.build
+++ b/meson.build
@@ -51,4 +51,5 @@ endif
 
 subdir('test')
 subdir('examples')
+subdir('tools')
 subdir('doc')

--- a/tools/gen-node-schema/main.c
+++ b/tools/gen-node-schema/main.c
@@ -1,0 +1,62 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright 2025, Olivier MATZ <zer0@droids-corp.org>
+ */
+
+#include <errno.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <ecoli.h>
+
+static void dump_schema(FILE *stdout, const struct ec_node_type *type)
+{
+	fprintf(stdout,
+		"\n"
+		"## %s\n"
+		"\n",
+		type->name);
+
+	if (type->schema == NULL) {
+		fprintf(stdout, "No generic schema.\n");
+		return;
+	}
+
+	fprintf(stdout, "```\n");
+	ec_config_schema_dump(stdout, type->schema, type->name);
+	fprintf(stdout, "```\n");
+}
+
+static bool check_dir(const char *path)
+{
+	DIR *dir = opendir(path);
+
+	if (dir == NULL)
+		return false;
+
+	closedir(dir);
+
+	return true;
+}
+
+int main(void)
+{
+	struct ec_node_type *type;
+
+	if (!check_dir("doc")) {
+		fprintf(stderr, "Failed to open doc directory: %s\n", strerror(errno));
+		fprintf(stderr, "Ensure that you run this tool from libecoli root directory\n");
+		return 1;
+	}
+
+	fprintf(stdout,
+		"# Node schemas\n"
+		"\n"
+		"This page lists all grammar node types supported by libecoli. For each node,\n"
+		"it shows its generic configuration schema, if supported.\n");
+
+	TAILQ_FOREACH (type, &node_type_list, next)
+		dump_schema(stdout, type);
+
+	return 0;
+}

--- a/tools/gen-node-schema/meson.build
+++ b/tools/gen-node-schema/meson.build
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2025, Olivier MATZ <zer0@droids-corp.org>
+
+gen_node_schema_sources = files(
+	'main.c',
+)
+
+ecoli_gen_node_schema = executable(
+	'ecoli-gen-node-schema',
+	gen_node_schema_sources,
+	include_directories : inc,
+	link_with : libecoli,
+	dependencies: [edit_dep])
+
+node_schema = custom_target(
+	'node-schema.md',
+	output: 'node-schema.md',
+	capture: true,
+	command: ecoli_gen_node_schema,
+)
+
+test(
+	'node_schema_test',
+	find_program('diff'),
+	args: ['-u', files('../../doc/node-schema.md'), node_schema],
+	suite: 'unit',
+)

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2025, Olivier MATZ <zer0@droids-corp.org>
+
+subdir('gen-node-schema')


### PR DESCRIPTION
This tool helps to generate up-to-date documentation. It browses all registered libecoli nodes types, and for each of them it generates a section in a markdown document that details its configuration API.

The result of this tool is added in this commit in doc/node-schema.md. It can be updated with "make node-schema", and a test checks that documentation is always up to date (so the CI will check it).