### PR TITLE
doc: comprehensive doxygen documentation improvements

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,17 +20,14 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-24.04
+    container: fedora:latest
     env:
       MESON_EXTRA_OPTS: --auto-features=disabled -Ddoc=enabled
     permissions:
       contents: read
     steps:
       - name: install system dependencies
-        run: |
-          set -xe
-          sudo apt-get update -qy
-          sudo apt-get install -qy --no-install-recommends \
-            doxygen gcc graphviz libc-dev meson ninja-build pkg-config
+        run: dnf install doxygen gcc graphviz make meson ninja-build pkgconf
       - uses: actions/checkout@v4
       - uses: actions/configure-pages@v5
       - run: make

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,13 +38,13 @@ commits). Follow these general rules:
   is not limited in length and may span over multiple paragraphs. Use proper
   English syntax, grammar and punctuation.
 - Address only one issue/topic per commit.
-- Describe your changes in imperative mood, e.g. *"make xyzzy do frotz"*
+- Describe your changes in the imperative mood, e.g. *"make xyzzy do frotz"*
   instead of *"[This patch] makes xyzzy do frotz"* or *"[I] changed xyzzy to do
   frotz"*, as if you are giving orders to the codebase to change its behaviour.
 - If you are fixing a GitHub issue, add an appropriate `Closes: <ISSUE_URL>`
   trailer.
 - If you are fixing a regression introduced by another commit, add a `Fixes:
-  <SHORT_ID_12_LONG> "<COMMIT_TITLE>"` trailer.
+  <sha> ("<title>")` trailer.
 - When in doubt, follow the format and layout of the recent existing commits.
 - The following trailers are accepted in commits. If you are using multiple
   trailers in a commit, it's preferred to also order them according to this
@@ -76,7 +76,7 @@ There is a great reference for commit messages in the
 IMPORTANT: you must sign-off your work using `git commit --signoff`. Follow the
 [Linux kernel developer's certificate of origin][linux-signoff] for more
 details. All contributions are made under the
-[BSD-3-Clause][https://spdx.org/licenses/BSD-3-Clause.html] license. Please use
+[BSD-3-Clause](https://spdx.org/licenses/BSD-3-Clause.html) license. Please use
 your real name and not a pseudonym. Here is an example:
 
     Signed-off-by: Robin Jarry <rjarry@redhat.com>
@@ -149,7 +149,7 @@ with a `Tested-by` trailer.
 You can follow the review process on GitHub [web
 UI](https://github.com/rjarry/libecoli/pulls).
 
-Wait for feedback. Address comments and amend changes to your original commit(s).
+Wait for feedback. Address comments and amend your original commit(s).
 Then you should push to refresh your branch which will update the pull request:
 
 ```console

--- a/README.md
+++ b/README.md
@@ -23,9 +23,10 @@ This library provides helpers to build interactive command line interfaces.
 * Extensible: the user can write its own nodes to provide specific features.
 * C API.
 
-## Architecture
+## Documentation
 
-See [architecture.md](/doc/architecture.md).
+See the [API documentation](https://rjarry.github.io/libecoli/) for details on
+grammar nodes, parsing, completion, and the interactive editing API.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -4,24 +4,95 @@
 
 [![Doxygen](https://img.shields.io/badge/doxygen-2C4AA8)](https://rjarry.github.io/libecoli/)
 
-libecoli stands for **E**xtensible **CO**mmand **LI**ne library.
+Libecoli is an **E**xtensible **CO**mmand **LI**ne library written in C that
+provides a modular, composable framework for building interactive command line
+interfaces with dynamic completion, contextual help, and parsing capabilities.
 
-This library provides helpers to build interactive command line interfaces.
+## Use Cases
 
-## What can it be used for?
+* Complex interactive command line interfaces (e.g., router or network
+  appliance CLIs).
+* Application arguments parsing with native bash completion support.
+* Generic grammar-based parsers.
 
-* Complex interactive command line interfaces in C (e.g.: a router CLI).
-* Application arguments parsing, natively supporting bash completion.
-* Generic parsers.
+## Features
 
-## Main Features
+* **Grammar-based parsing**: Define command syntax using composable grammar
+  nodes that form a directed graph.
+* **Dynamic completion**: Automatic TAB completion based on the grammar, with
+  support for runtime-generated suggestions.
+* **Contextual help**: Display relevant help messages based on current input
+  position.
+* **Shell-like tokenization**: Built-in lexers handle quoting, escaping, and
+  variable expansion.
+* **Interactive editing**: Integration with libedit for line editing, history,
+  and key bindings.
+* **YAML configuration**: Define grammars in YAML files instead of C code.
+* **Extensible**: Write custom node types to provide application-specific
+  features.
 
-* Dynamic completion.
-* Contextual help.
-* Integrated with libedit, but can use any readline-like library.
-* Modular: the cli behavior is defined through an assembly of basic nodes.
-* Extensible: the user can write its own nodes to provide specific features.
-* C API.
+## Quick Example
+
+```c
+#include <ecoli.h>
+
+static bool done;
+
+static int hello_cb(const struct ec_pnode *p) {
+	const char *name = ec_strvec_val(
+		ec_pnode_get_strvec(ec_pnode_find(p, "NAME")), 0);
+	printf("Hello, %s!\n", name);
+	return 0;
+}
+
+static int exit_cb(const struct ec_pnode *p) {
+	(void)p;
+	done = true;
+	return 0;
+}
+
+static bool check_exit_cb(void *priv) {
+	(void)priv;
+	return done;
+}
+
+int main(void) {
+	struct ec_node *cmd, *root;
+	struct ec_editline *edit;
+
+	ec_init();
+
+	// Build grammar: "hello <name>" or "exit"
+	root = ec_node("or", EC_NO_ID);
+
+	cmd = EC_NODE_SEQ(EC_NO_ID,
+		ec_node_str(EC_NO_ID, "hello"),
+		ec_node_any("NAME", NULL));
+	ec_interact_set_callback(cmd, hello_cb);
+	ec_interact_set_help(cmd, "Say hello to someone.");
+	ec_node_or_add(root, cmd);
+
+	cmd = ec_node_str(EC_NO_ID, "exit");
+	ec_interact_set_callback(cmd, exit_cb);
+	ec_interact_set_help(cmd, "Exit the program.");
+	ec_node_or_add(root, cmd);
+
+	// Add shell lexer for quote/escape handling
+	root = ec_node_sh_lex(EC_NO_ID, root);
+
+	// Create interactive session
+	edit = ec_editline("example", stdin, stdout, stderr, 0);
+	ec_editline_set_prompt(edit, "> ");
+	ec_editline_set_node(edit, root);
+	ec_editline_interact(edit, check_exit_cb, NULL);
+
+	ec_editline_free(edit);
+	ec_node_free(root);
+	ec_exit();
+
+	return 0;
+}
+```
 
 ## Documentation
 

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -4,11 +4,12 @@
 PROJECT_NAME           = "Libecoli"
 PROJECT_BRIEF          = "Extensible COmmand LIne library"
 PROJECT_NUMBER         = @VERSION@
-INPUT                  = @TOPDIR@/include @TOPDIR@/include/ecoli
+INPUT                  = @TOPDIR@/include @TOPDIR@/include/ecoli @TOPDIR@/examples
 OUTPUT_DIRECTORY       = @OUTPUT@
-FILE_PATTERNS          = *.h
+FILE_PATTERNS          = *.h *.c
+RECURSIVE              = YES
 
-EXCLUDE_SYMBOLS        = __* TAILQ_* free* init* realloc malloc boolean complete desc dict u64 test type size string subschema parse node name list key i64 help set_config schema priority exit get_child get_children_count eval_* @1* @3* lstat opendir readdir closedir dirfd fstatat
+EXCLUDE_SYMBOLS        = __* TAILQ_* free* init* realloc malloc boolean complete desc dict u64 test type size string subschema parse node name list key i64 help set_config schema priority exit get_child get_children_count eval_* @1* @3* lstat opendir readdir closedir dirfd fstatat ip_pool*
 
 
 OPTIMIZE_OUTPUT_FOR_C   = YES

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -4,10 +4,11 @@
 PROJECT_NAME           = "Libecoli"
 PROJECT_BRIEF          = "Extensible COmmand LIne library"
 PROJECT_NUMBER         = @VERSION@
-INPUT                  = @TOPDIR@/include @TOPDIR@/include/ecoli @TOPDIR@/examples
+INPUT                  = @TOPDIR@/include @TOPDIR@/include/ecoli @TOPDIR@/examples @TOPDIR@/doc
 OUTPUT_DIRECTORY       = @OUTPUT@
-FILE_PATTERNS          = *.h *.c
+FILE_PATTERNS          = *.h *.c *.md
 RECURSIVE              = YES
+IMAGE_PATH             = @TOPDIR@/doc
 
 EXCLUDE_SYMBOLS        = __* TAILQ_* free* init* realloc malloc boolean complete desc dict u64 test type size string subschema parse node name list key i64 help set_config schema priority exit get_child get_children_count eval_* @1* @3* lstat opendir readdir closedir dirfd fstatat ip_pool*
 

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -4,7 +4,7 @@
 PROJECT_NAME           = "Libecoli"
 PROJECT_BRIEF          = "Extensible COmmand LIne library"
 PROJECT_NUMBER         = @VERSION@
-INPUT                  = @TOPDIR@/include @TOPDIR@/include/ecoli @TOPDIR@/examples @TOPDIR@/doc
+INPUT                  = @TOPDIR@/include @TOPDIR@/include/ecoli @TOPDIR@/examples @TOPDIR@/doc @OUTPUT@
 OUTPUT_DIRECTORY       = @OUTPUT@
 FILE_PATTERNS          = *.h *.c *.md
 RECURSIVE              = YES

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -1,28 +1,28 @@
-# Architecture
+@page architecture Architecture
 
-Most of *libecoli* is written in C. It provides a C API to ease the
-creation of interactive command line interfaces. It is split in several
-parts:
+Libecoli is written in C and provides an API for building interactive command
+line interfaces. The library consists of several components:
 
-- the core: it provides the main API to parse and complete strings.
-- ecoli nodes: this is the modular part of *libecoli*. Each node
-  implements a specific parsing (integers, strings, regular expressions,
-  sequence, ...)
-- yaml parser: load an ecoli tree described in yaml.
-- editline: helpers to instantiate an *editline* and connect it to
-  *libecoli*.
-- utilities: logging, string, strings vector, hash table, ...
+- **Core**: The main API for parsing and completing input strings.
+- **Nodes**: The modular component of libecoli. Each node type implements
+  specific parsing behavior (integers, strings, regular expressions,
+  sequences, etc.).
+- **YAML parser**: Loads grammar trees from YAML configuration files.
+- **Editline**: Integration helpers for the editline library.
+- **Utilities**: Logging, string manipulation, string vectors, hash tables,
+  and other support functions.
 
-## The grammar graph
+## The Grammar Graph
 
-The *ecoli nodes* are organized in a graph. Actually, it is mostly a
-tree, but loops are allowed in some cases. An *ecoli grammar tree*
-describes how the input is parsed and completed. Let's take a simple
-example:
+Nodes are organized into a directed graph that defines the grammar. Although
+this structure is typically a tree, loops are permitted in certain cases. The
+grammar graph describes how input is parsed and completed.
 
-![simple-tree.svg](https://raw.githubusercontent.com/rjarry/libecoli/master/doc/simple-tree.svg)
+Consider the following example:
 
-We can also represent it as text like this:
+![Simple grammar tree](simple-tree.svg)
+
+The same structure can be represented textually as:
 
 ```
 sh_lex(
@@ -35,97 +35,127 @@ sh_lex(
 )
 ```
 
-This tree matches the following strings:
+This grammar matches:
 
-- `foo`
-- `foo bar`
+- `"foo"`
+- `"foo bar"`
 
-But, for instance, it does **not** match the following strings:
+It does not match:
 
-- `bar`
-- `foobar`
-- (empty string)
+- `"bar"`
+- `"foobar"`
+- `""` (empty input)
 
-## Parsing an input
+## Parsing
 
-When the *libecoli* parses an input, it browses the tree (depth first
-search) and returns an *ecoli parse tree*. Let's decompose what is done
-when `ec_parse_strvec(root_node, input)` is called, step by step:
+When libecoli parses input, it traverses the grammar graph using depth-first
+search and constructs a parse tree. The following example illustrates the
+process when @ref ec_parse_strvec() is called:
 
-1. The initial input is a string vector `["foo bar"]`.
-2. The `sh_lex` node splits the input as a shell would have done it, in
-   `["foo", "bar"]`, and passes it to its child.
-3. The *seq* node (sequence) passes the input to its first child.
-4. The *str* node matches if the first element of the string vector is
-   `foo`. This is the case, so it returns the number of eaten
-   strings (1) to its parent.
-5. The *seq* node passes the remaining part `["bar"]` to its next
-   child.
-6. The option node passes the string vector to its child, which
-   matches. It returns 1 to its parent.
-7. The *seq* node has no more child, it returns the number of eaten
-   strings in the vector (2).
-8. Finally, `sh_lex` compares the returned value to the number of
-   strings in its initial vector, and return 1 (match) to its caller.
+1. The input is a string vector containing `["foo bar"]`.
+2. The `sh_lex` node tokenizes the input using shell lexing rules, producing
+   `["foo", "bar"]`, and passes this to its child.
+3. The `seq` node forwards the input to its first child.
+4. The `str` node checks whether the first token equals `foo`. Since it does,
+   the node returns 1 (the number of consumed tokens) to its parent.
+5. The `seq` node passes the remaining tokens `["bar"]` to its next child.
+6. The `option` node forwards the input to its child, which matches and
+   returns 1.
+7. The `seq` node has processed all children and returns 2 (total consumed
+   tokens).
+8. The `sh_lex` node compares the return value against its token count and
+   returns 1 (success) to the caller.
 
-If a node does not match, it returns `EC_PARSE_NOMATCH` to its parent,
-and it is propagated until it reaches a node that handle the case. For
-instance, the *or* node is able to handle this error. If a child does
-not match, the next one is tried until it finds one that matches.
+When a node fails to match, it returns @ref EC_PARSE_NOMATCH to its parent. This
+value propagates up the tree until a node handles the failure. For example, the
+`or` node tries each child in sequence until one matches.
 
-## The parse tree
+## The Parse Tree
 
-Let's take another simple example.
+Consider another example grammar:
 
-![simple-tree2.svg](https://raw.githubusercontent.com/rjarry/libecoli/master/doc/simple-tree2.svg)
+![Grammar with or node](simple-tree2.svg)
 
-In that case, there is no lexer (the `sh_lex` node), so the input must
-be a string vector that is already split. For instance, it matches:
+Without a lexer node, the input must already be tokenized. This grammar matches:
 
 - `["foo"]`
 - `["bar", "1"]`
 - `["bar", "100"]`
 
-But it does **not** match:
+It does not match:
 
-- `["bar 1"]`, because there is no `sh_lex` node on the top of the tree
-- `["bar"]`
-- `[]` (empty vector)
+- `["bar 1"]` (not tokenized)
+- `["bar"]` (missing required argument)
+- `[]` (empty input)
 
-At the time the input is parsed, a *parse tree* is built. When it
-matches, it describes which part of the *ecoli grammar graph* that
-actually matched, and what input matched for each node.
+During parsing, a parse tree is constructed. When parsing succeeds, the tree
+describes which grammar nodes matched and what input each node consumed.
 
-Passing `["bar", "1"]` to the previous tree would result in the
-following *parse tree*:
+Parsing `["bar", "1"]` produces the following parse tree:
 
-![parse-tree.svg](https://raw.githubusercontent.com/rjarry/libecoli/master/doc/parse-tree.svg)
+![Parse tree structure](parse-tree.svg)
 
-Each node of the *parse tree* references the node of the *grammar graph*
-that matched. It also stores the string vector that matched.
+Each parse tree node references the grammar node that matched and stores the
+corresponding input tokens:
 
-![parse-tree2.svg](https://raw.githubusercontent.com/rjarry/libecoli/master/doc/parse-tree2.svg)
+![Parse tree with token references](parse-tree2.svg)
 
-We can see that not all of the grammar nodes are referenced, since the
-str("foo") node was not parsed. Similarly, one grammar node can be
-referenced several times in the parse tree, as we can see it in the
-following example that matches `[]`, `[foo]`, `[foo, foo]`, ...
+Not all grammar nodes appear in the parse tree. In this example, `str("foo")`
+was not matched and therefore does not appear. Conversely, a single grammar node
+may appear multiple times in the parse tree. Consider this grammar that matches
+zero or more occurrences of `foo`:
 
-![simple-tree3.svg](https://raw.githubusercontent.com/rjarry/libecoli/master/doc/simple-tree3.svg)
+![Grammar with many node](simple-tree3.svg)
 
-Here is the resulting *parse tree* when the input vector is `[foo, foo,
-foo]`:
+Parsing `[foo, foo, foo]` produces:
 
-![parse-tree3.svg](https://raw.githubusercontent.com/rjarry/libecoli/master/doc/parse-tree3.svg)
+![Parse tree with repeated matches](parse-tree3.svg)
 
-## TODO
+## Node Identifiers
 
-- Node identifiers
-- completions
-- C example
-- ec_config
-- parse yaml
-- params are consumed
-- nodes
-- attributes
-- extending lib with external nodes (in dev guide?)
+Each grammar node may have an optional string identifier. This identifier
+enables locating specific nodes in the parse tree after parsing completes. For
+example, a node created with `ec_node_int("COUNT", 0, 100, 10)` can be found
+using `ec_pnode_find(parse_tree, "COUNT")`.
+
+Identifiers need not be unique within the grammar graph. When multiple nodes
+share the same identifier, @ref ec_pnode_find() returns the first match. Use
+@ref ec_pnode_find_next() to iterate through additional matches.
+
+## Completion
+
+The completion mechanism operates similarly to parsing but collects possible
+continuations instead of validating input. When the user requests completion,
+libecoli traverses the grammar graph and queries each node for tokens that could
+follow the current partial input.
+
+Completions are grouped by the grammar node that produced them. Each
+completion item has one of three types:
+
+- @ref EC_COMP_FULL - A complete token (e.g., a command keyword).
+- @ref EC_COMP_PARTIAL - A partial token requiring further input (e.g.,
+  a directory path).
+- @ref EC_COMP_UNKNOWN - Valid input that cannot be completed (e.g., an
+  arbitrary string matching a regular expression).
+
+## Node Attributes
+
+Grammar nodes support arbitrary key-value attributes. The interactive layer
+uses these attributes to store:
+
+- Help text displayed during completion or on errors
+- Callbacks invoked when parsing succeeds
+- Short descriptions for contextual help
+
+Use @ref ec_node_attrs() to access the attribute dictionary and manipulate it with
+@ref ec_dict_set() and @ref ec_dict_get(). The @ref ecoli_interact API provides
+convenience functions such as @ref ec_interact_set_help() and
+@ref ec_interact_set_callback().
+
+## Node Configuration
+
+Nodes support a generic configuration system for setting parameters after
+creation. Each node type defines a schema describing its configuration options.
+The YAML parser uses this system to instantiate nodes from configuration files.
+
+See @ref ecoli_config for details.

--- a/doc/gen-node-schema.c
+++ b/doc/gen-node-schema.c
@@ -1,0 +1,66 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright 2025, Olivier MATZ <zer0@droids-corp.org>
+ */
+
+#include <err.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <ecoli.h>
+
+/* Map node type names to doxygen group names when they differ. */
+static const char *type_to_group(const char *name)
+{
+	if (strcmp(name, "uint") == 0)
+		return "int";
+	return name;
+}
+
+static void dump_schema(FILE *f, const struct ec_node_type *type)
+{
+	fprintf(f, "@addtogroup ecoli_node_%s\n", type_to_group(type->name));
+	fprintf(f, "@{\n\n");
+	fprintf(f, "<b>Configuration Schema</b>\n\n");
+
+	if (type->schema == NULL) {
+		fprintf(f, "No configuration schema.\n");
+	} else {
+		fprintf(f, "```c\n");
+		ec_config_schema_dump(f, type->schema, type->name);
+		fprintf(f, "```\n");
+	}
+
+	fprintf(f, "\n@}\n");
+}
+
+int main(int argc, char **argv)
+{
+	struct ec_node_type *type;
+	const char *dir, *stamp;
+	char fname[PATH_MAX];
+	FILE *f;
+
+	if (argc != 3)
+		errx(EXIT_FAILURE, "invalid arguments. usage: %s DIR STAMP_FILE", argv[0]);
+
+	dir = argv[1];
+	stamp = argv[2];
+
+	TAILQ_FOREACH (type, &node_type_list, next) {
+		snprintf(fname, sizeof(fname), "%s/node-%s-schema.md", dir, type->name);
+		printf("generating %s ...\n", fname);
+		f = fopen(fname, "w");
+		if (f == NULL)
+			errx(EXIT_FAILURE, "failed to create file: %s", fname);
+		dump_schema(f, type);
+		fclose(f);
+	}
+
+	f = fopen(stamp, "w");
+	if (f == NULL)
+		errx(EXIT_FAILURE, "failed to created stamp file: %s", stamp);
+	fclose(f);
+
+	return 0;
+}

--- a/doc/main.md
+++ b/doc/main.md
@@ -1,0 +1,207 @@
+@mainpage About Libecoli
+
+Libecoli is an <b>E</b>xtensible <b>CO</b>mmand <b>LI</b>ne library written in
+C that provides a modular, composable framework for building interactive command
+line interfaces with dynamic completion, contextual help, and parsing
+capabilities.
+
+Project page: https://github.com/rjarry/libecoli
+
+## Key Features
+
+- **Grammar-based parsing**: Define command syntax using composable grammar
+  nodes that form a directed graph.
+
+- **Dynamic completion**: Automatic TAB completion based on the grammar, with
+  support for runtime-generated suggestions.
+
+- **Contextual help**: Display relevant help messages based on current input
+  position.
+
+- **Shell-like tokenization**: Built-in lexers handle quoting, escaping, and
+  variable expansion.
+
+- **Interactive editing**: Integration with libedit for line editing, history,
+  and key bindings.
+
+- **YAML configuration**: Define grammars in YAML files instead of C code.
+
+- **Expression evaluation**: Parse and evaluate arithmetic or custom
+  expressions with user-defined operators.
+
+## Core Concepts
+
+### Grammar Graph
+
+A grammar is built by composing @ref ecoli_nodes into a directed graph. Each
+node type matches specific input patterns:
+
+- **Terminal nodes** match actual input tokens: @ref ec_node_str() matches
+  a literal string, @ref ec_node_int() matches integers, @ref ec_node_re()
+  matches regular expressions, the file node matches filesystem paths.
+
+- **Composite nodes** combine other nodes: @ref ec_node_seq() matches children
+  in sequence, @ref ec_node_or() matches any one child, @ref ec_node_many()
+  matches a child repeatedly, @ref ec_node_option() makes a child optional.
+
+- **Lexer nodes** tokenize raw input before passing to children:
+  @ref ec_node_sh_lex() provides shell-like tokenization with quote handling.
+
+### Parsing
+
+The @ref ecoli_parse API validates input against a grammar and produces a parse
+tree. Each node in the tree references the grammar node that matched it and the
+tokens it consumed. Use @ref ec_pnode_find() to locate specific nodes by their
+identifier and extract matched values.
+
+### Completion
+
+The @ref ecoli_complete API generates completion suggestions for partial input.
+Completions are grouped by the grammar node that produced them and can be
+filtered by type (full match, partial match, or unknown).
+
+### Interactive Mode
+
+The @ref ecoli_editline API provides a complete interactive command line with:
+
+- Line editing with libedit
+- TAB and `?` key completion
+- Command history with file persistence
+- Callback-based command execution
+- Contextual help display on errors
+
+## Quick Example
+
+```c
+#include <ecoli.h>
+
+static bool done;
+
+static int hello_cb(const struct ec_pnode *p) {
+	const char *name = ec_strvec_val(
+		ec_pnode_get_strvec(ec_pnode_find(p, "NAME")), 0);
+	printf("Hello, %s!\n", name);
+	return 0;
+}
+
+static int exit_cb(const struct ec_pnode *p) {
+	(void)p;
+	done = true;
+	return 0;
+}
+
+static bool check_exit_cb(void *priv) {
+	(void)priv;
+	return done;
+}
+
+int main(void) {
+	struct ec_node *cmd, *root;
+	struct ec_editline *edit;
+
+	ec_init();
+
+	// Build grammar: "hello <name>" or "exit"
+	root = ec_node("or", EC_NO_ID);
+
+	cmd = EC_NODE_SEQ(EC_NO_ID,
+		ec_node_str(EC_NO_ID, "hello"),
+		ec_node_any("NAME", NULL));
+	ec_interact_set_callback(cmd, hello_cb);
+	ec_interact_set_help(cmd, "Say hello to someone.");
+	ec_node_or_add(root, cmd);
+
+	cmd = ec_node_str(EC_NO_ID, "exit");
+	ec_interact_set_callback(cmd, exit_cb);
+	ec_interact_set_help(cmd, "Exit the program.");
+	ec_node_or_add(root, cmd);
+
+	// Add shell lexer for quote/escape handling
+	root = ec_node_sh_lex(EC_NO_ID, root);
+
+	// Create interactive session
+	edit = ec_editline("example", stdin, stdout, stderr, 0);
+	ec_editline_set_prompt(edit, "> ");
+	ec_editline_set_node(edit, root);
+	ec_editline_interact(edit, check_exit_cb, NULL);
+
+	ec_editline_free(edit);
+	ec_node_free(root);
+	ec_exit();
+
+	return 0;
+}
+```
+
+See the [Examples](examples.html) page for complete working examples
+demonstrating grammar construction, completion, readline integration, custom
+node types, and dynamic completion from runtime data.
+
+## Available Node Types
+
+### Terminal Nodes
+
+| Node Type | Description |
+|-----------|-------------|
+| @ref ecoli_node_str | Matches a specific literal string |
+| @ref ecoli_node_int | Matches signed integers with range/base constraints |
+| @ref ecoli_node_re | Matches input against a POSIX extended regex |
+| @ref ecoli_node_file | Matches and completes filesystem paths |
+| @ref ecoli_node_any | Matches any single token |
+| @ref ecoli_node_empty | Matches zero tokens (always succeeds) |
+| @ref ecoli_node_none | Matches nothing (always fails) |
+| @ref ecoli_node_space | Matches whitespace |
+
+### Composite Nodes
+
+| Node Type | Description |
+|-----------|-------------|
+| @ref ecoli_node_seq | Matches children in strict order |
+| @ref ecoli_node_or | Matches any one of its children |
+| @ref ecoli_node_many | Matches a child repeatedly (with min/max) |
+| @ref ecoli_node_option | Makes a child optional |
+| @ref ecoli_node_subset | Matches any subset of children in any order |
+
+### Advanced Nodes
+
+| Node Type | Description |
+|-----------|-------------|
+| @ref ecoli_node_cmd | Parses commands using a format string syntax |
+| @ref ecoli_node_expr | Parses expressions with operators and precedence |
+| @ref ecoli_node_dynamic | Builds grammar dynamically at parse time |
+| @ref ecoli_node_dynlist | Matches names from a runtime-generated list |
+| @ref ecoli_node_cond | Conditionally matches based on an expression |
+| @ref ecoli_node_once | Prevents a child from matching more than once |
+| @ref ecoli_node_bypass | Pass-through node for building graph loops |
+
+### Lexer Nodes
+
+| Node Type | Description |
+|-----------|-------------|
+| @ref ecoli_node_sh_lex | Shell-like tokenization with quotes and escapes |
+| @ref ecoli_node_re_lex | Regex-based tokenization |
+
+## API Reference
+
+- @ref architecture - How libecoli works internally
+- @ref ecoli_init - Library initialization
+- @ref ecoli_nodes - Grammar node types and operations
+- @ref ecoli_parse - Parsing API
+- @ref ecoli_complete - Completion API
+- @ref ecoli_editline - Interactive editing with libedit
+- @ref ecoli_interact - Command callbacks and help system
+- @ref ecoli_yaml - YAML grammar import/export
+- @ref ecoli_config - Node configuration system
+- @ref ecoli_log - Logging facilities
+
+## Real-World Usage
+
+Libecoli powers the CLI of several production systems including the
+[grout](https://github.com/DPDK/grout) graph router and 6WIND's Virtual Service
+Router. These projects demonstrate patterns such as:
+
+- Modular command registration with constructor functions
+- Dynamic completion callbacks that query live system state
+- Hierarchical command contexts (e.g., `ip route add ...`)
+- Typed argument extraction helpers
+- JSON export of command trees for documentation generation

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -11,6 +11,19 @@ cdata.set('VERSION', meson.project_version())
 cdata.set('OUTPUT', meson.current_build_dir())
 cdata.set('TOPDIR', meson.project_source_root())
 
+ecoli_gen_node_schema = executable(
+	'gen-node-schema',
+	files('gen-node-schema.c'),
+	include_directories : inc,
+	link_with: libecoli,
+)
+
+node_schemas = custom_target(
+	'node-schemas',
+	output: 'node-schemas',
+	command: [ecoli_gen_node_schema, meson.current_build_dir(), '@OUTPUT@'],
+)
+
 man_cdata = configuration_data()
 man_cdata.merge_from(cdata)
 man_cdata.set('GENERATE_HTML', 'NO')
@@ -26,6 +39,7 @@ custom_target(
 	output: 'man',
 	command: [doxygen, '@INPUT@'],
 	build_by_default: true,
+	depends: node_schemas,
 	depend_files: doc_sources,
 	install: true,
 	install_dir: get_option('datadir'))
@@ -45,6 +59,7 @@ custom_target(
 	output: 'html',
 	command: [doxygen, '@INPUT@'],
 	build_by_default: true,
+	depends: node_schemas,
 	depend_files: doc_sources,
 	install: true,
 	install_dir: join_paths(get_option('datadir'), 'doc', 'libecoli'))

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -26,6 +26,7 @@ custom_target(
 	output: 'man',
 	command: [doxygen, '@INPUT@'],
 	build_by_default: true,
+	depend_files: doc_sources,
 	install: true,
 	install_dir: get_option('datadir'))
 
@@ -44,5 +45,6 @@ custom_target(
 	output: 'html',
 	command: [doxygen, '@INPUT@'],
 	build_by_default: true,
+	depend_files: doc_sources,
 	install: true,
 	install_dir: join_paths(get_option('datadir'), 'doc', 'libecoli'))

--- a/examples/extension-editline/main.c
+++ b/examples/extension-editline/main.c
@@ -2,6 +2,37 @@
  * Copyright 2025, Olivier MATZ <zer0@droids-corp.org>
  */
 
+/**
+ * @example extension-editline/main.c
+ * Define custom node types with specialized parsing and completion.
+ *
+ * Demonstrates creating a custom grammar node type (bool_tuple) with its
+ * own parsing and completion logic. The bool_tuple node parses and completes
+ * tuples of booleans like "(true,false,true)" and converts them to an integer
+ * where each boolean becomes a bit (e.g. "(true,false,true)" = 101 binary = 5).
+ *
+ * The custom node (node_bool_tuple.c) implements:
+ * - Parsing: validates input matches the exact grammar (bool,bool,...)
+ * - Completion: provides context-aware suggestions at each parsing state
+ *   (opening paren, true/false keywords, comma, closing paren)
+ *
+ * The main program registers two commands:
+ * - "convert <bool_tuple>" - parses the tuple and prints its integer value
+ * - "exit" - quits the program
+ *
+ * Example session:
+ * @code
+ * extension> convert (true,false,true)
+ * Integer value for (true,false,true) is 5
+ * extension> convert (false,true)
+ * Integer value for (false,true) is 1
+ * extension> exit
+ * Exit !
+ * @endcode
+ *
+ * See also node_bool_tuple.c for the node type implementation.
+ */
+
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/examples/extension-editline/meson.build
+++ b/examples/extension-editline/meson.build
@@ -10,6 +10,7 @@ extension_editline_sources = files(
 	'main.c',
 	'node_bool_tuple.c',
 )
+doc_sources += extension_editline_sources
 
 ecoli_extension_editline = executable(
 	'ecoli-extension-editline',

--- a/examples/parse-yaml/meson.build
+++ b/examples/parse-yaml/meson.build
@@ -9,6 +9,7 @@ endif
 parse_yaml_sources = files(
 	'parse-yaml.c',
 )
+doc_sources += parse_yaml_sources
 
 ecoli_parse_yaml = executable(
 	'ecoli-parse-yaml',

--- a/examples/parse-yaml/parse-yaml.c
+++ b/examples/parse-yaml/parse-yaml.c
@@ -2,6 +2,30 @@
  * Copyright 2018, Olivier MATZ <zer0@droids-corp.org>
  */
 
+/**
+ * @example parse-yaml/parse-yaml.c
+ * Load grammar from YAML and parse or complete input.
+ *
+ * Demonstrates loading a grammar definition from a YAML file using
+ * ec_yaml_import() and using it to parse or complete command line input.
+ *
+ * Example session using test.yaml grammar:
+ * @code
+ * $ ./parse-yaml -i test.yaml -o /dev/stdout
+ * parse-yaml> hello john
+ * ec_node1_id='sh_lex'
+ * ec_node1_type='sh_lex'
+ * ec_node1_strvec_len=1
+ * ec_node1_str0='hello john'
+ * ec_node1_first_child='ec_node2'
+ * ec_node2_id='hello'
+ * ...
+ * $ ./parse-yaml -i test.yaml -o /dev/null -c hello ""
+ * john
+ * mike
+ * @endcode
+ */
+
 #include <errno.h>
 #include <getopt.h>
 #include <stdio.h>

--- a/examples/pool-editline/main.c
+++ b/examples/pool-editline/main.c
@@ -2,6 +2,35 @@
  * Copyright 2025, Olivier MATZ <zer0@droids-corp.org>
  */
 
+/**
+ * @example pool-editline/main.c
+ * Dynamic completion from runtime data structures.
+ *
+ * Demonstrates using ec_node_dynlist() to generate completions from
+ * runtime data. The example manages IP address pools and provides
+ * completion for pool names and addresses.
+ *
+ * Example session:
+ * @code
+ * pool> pool list
+ * No pool
+ * pool> pool add servers
+ * pool> pool add clients
+ * pool> pool list
+ * servers
+ * clients
+ * pool> addr pool servers add 192.168.1.1
+ * pool> addr pool servers add 192.168.1.2
+ * pool> addr pool servers list
+ * 192.168.1.1
+ * 192.168.1.2
+ * pool> addr pool servers del 192.168.1.1
+ * pool> pool del clients
+ * pool> exit
+ * Exit !
+ * @endcode
+ */
+
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/examples/pool-editline/meson.build
+++ b/examples/pool-editline/meson.build
@@ -10,6 +10,7 @@ pool_editline_sources = files(
 	'ip_pool.c',
 	'main.c',
 )
+doc_sources += pool_editline_sources + files('ip_pool.h')
 
 ecoli_pool_editline = executable(
 	'ecoli-pool-editline',

--- a/examples/readline/main.c
+++ b/examples/readline/main.c
@@ -2,6 +2,36 @@
  * Copyright 2016, Olivier MATZ <zer0@droids-corp.org>
  */
 
+/**
+ * @example readline/main.c
+ * Integration with GNU readline instead of libedit.
+ *
+ * Demonstrates how to use libecoli's completion API with GNU readline
+ * by implementing custom completion functions.
+ *
+ * Example session:
+ * @code
+ * > hello john 5
+ * parse(match=yes, len=3)
+ *  seq(match=yes, len=3)
+ *   str(hello)(match=yes, len=1) "hello"
+ *   or(name)(match=yes, len=1)
+ *    str(john)(match=yes, len=1) "john"
+ *   int(int)(match=yes, len=1) "5"
+ * > good morning bob
+ * parse(match=yes, len=3)
+ *  cmd(match=yes, len=3)
+ *   cmd(name)(match=yes, len=1) "bob"
+ * > buy potatoes
+ * parse(match=yes, len=2)
+ *  cmd(match=yes, len=2)
+ * > bye
+ * parse(match=yes, len=1)
+ *  seq(match=yes, len=1)
+ *   str(bye)(match=yes, len=1) "bye"
+ * @endcode
+ */
+
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/examples/readline/meson.build
+++ b/examples/readline/meson.build
@@ -9,6 +9,7 @@ endif
 readline_sources = files(
 	'main.c',
 )
+doc_sources += readline_sources
 
 ecoli_readline = executable(
 	'ecoli-readline',

--- a/examples/simple-editline/main.c
+++ b/examples/simple-editline/main.c
@@ -2,6 +2,27 @@
  * Copyright 2025, Olivier MATZ <zer0@droids-corp.org>
  */
 
+/**
+ * @example simple-editline/main.c
+ * Basic interactive CLI with commands, help, and completion.
+ *
+ * Demonstrates building a grammar using sequence, or, and option nodes,
+ * setting help text and callbacks on commands, and using the editline
+ * integration for interactive input with TAB completion.
+ *
+ * Example session:
+ * @code
+ * simple> hello john
+ * you say hello to john
+ * simple> hello mike 3
+ * you say hello to mike 3 times
+ * simple> bye johnny
+ * you say bye to johnny
+ * simple> exit
+ * Exit !
+ * @endcode
+ */
+
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/examples/simple-editline/meson.build
+++ b/examples/simple-editline/meson.build
@@ -9,6 +9,7 @@ endif
 simple_editline_sources = files(
 	'main.c',
 )
+doc_sources += simple_editline_sources
 
 ecoli_simple_editline = executable(
 	'ecoli-simple-editline',

--- a/include/ecoli.h
+++ b/include/ecoli.h
@@ -2,23 +2,6 @@
  * Copyright 2016, Olivier MATZ <zer0@droids-corp.org>
  */
 
-/**
- * @anchor main_page
- * @mainpage About Libecoli
- *
- * This is the C API documentation of libecoli. This library provides
- * helpers to build interactive command line interfaces.
- *
- * To create a command line parser, one should create a grammar graph
- * which is composed of @ref ecoli_nodes. Then an input can be
- * parsed or completed, respectively using the @ref ecoli_parse and @ref
- * ecoli_complete APIs.
- *
- * The library also provides helpers to create a an interactive command
- * line based on @ref ecoli_editline library, and a @ref ecoli_yaml parser for
- * grammar graphs.
- */
-
 #pragma once
 
 #include <ecoli/assert.h>

--- a/include/ecoli/assert.h
+++ b/include/ecoli/assert.h
@@ -21,7 +21,7 @@
 /**
  * Abort if the condition is false.
  *
- * If expression is false this macro will prints an error message to
+ * If expression is false, this macro will print an error message to
  * standard error and terminates the program by calling abort(3).
  *
  * @param expr

--- a/include/ecoli/complete.h
+++ b/include/ecoli/complete.h
@@ -30,19 +30,25 @@
 #include <sys/types.h>
 
 struct ec_node;
-struct ec_comp_item;
-struct ec_comp_group;
-struct ec_comp;
 struct ec_strvec;
+
+/** A completion item. */
+struct ec_comp_item;
+
+/** A group of completion items sharing the same parsing state. */
+struct ec_comp_group;
+
+/** A list of completion items and groups. */
+struct ec_comp;
 
 /**
  * Completion item type.
  */
 enum ec_comp_type {
-	EC_COMP_UNKNOWN = 0x1,
+	EC_COMP_UNKNOWN = 0x1, /**< Valid token but completion not possible. */
 	EC_COMP_FULL = 0x2, /**< The item is fully completed. */
 	EC_COMP_PARTIAL = 0x4, /**< The item is partially completed. */
-	EC_COMP_ALL = 0x7,
+	EC_COMP_ALL = 0x7, /**< All completion types. */
 };
 
 /**

--- a/include/ecoli/complete.h
+++ b/include/ecoli/complete.h
@@ -11,15 +11,15 @@
  * This file provides helpers to list and manipulate the possible
  * completions for a given input.
  *
- * Use ec_complete_strvec() to complete a vector of strings when
+ * Use ::ec_complete_strvec() to complete a vector of strings when
  * the input is already split into several tokens. You can use
- * ec_complete() if you know that the size of the vector is
+ * ::ec_complete() if you know that the size of the vector is
  * 1. This is common if your grammar graph includes a lexer that
  * will tokenize the input.
  *
  * These two functions return a pointer to an ::ec_comp structure, that
  * lists the possible completions. The completions are grouped into
- * ec_comp_group. All completions items of a group shares the same parsing
+ * ::ec_comp_group. All completion items of a group share the same parsing
  * state and are issued by the same node.
  */
 
@@ -54,7 +54,7 @@ enum ec_comp_type {
 /**
  * Get the list of completions from a string input.
  *
- * It is equivalent that calling ec_complete_strvec() with a
+ * It is equivalent to calling ec_complete_strvec() with a
  * vector that only contains 1 element, the input string. Using this
  * function is often more convenient if you get your input from a
  * buffer, because you won't have to create a vector. Usually, it means
@@ -77,15 +77,15 @@ struct ec_comp *ec_complete(const struct ec_node *node, const char *str);
  *
  * This function tries to complete the last element of the given string
  * vector. For instance, to complete with file names in an equivalent of
- * the `cat` shell command, the passed vector should be ["cat", ""] (and
- * not ["cat"]). To complete with files starting with "x", the passed
- * vector should be ["cat", "x"].
+ * the `cat` shell command, the passed vector should be `["cat", ""]` (and
+ * not `["cat"]`). To complete with files starting with `"x"`, the passed
+ * vector should be `["cat", "x"]`.
  *
  * To get the completion list, the engine parses the beginning of the
  * input using the grammar graph. The resulting parsing tree is saved and
  * attached to each completion group.
  *
- * The result is a ec_comp structure pointer, which contains several
+ * The result is a ::ec_comp structure pointer, which contains several
  * groups of completion items.
  *
  * @param node
@@ -121,8 +121,8 @@ struct ec_strvec *ec_complete_strvec_expand(
 /**
  * Get the list of completions of a child node.
  *
- * This function is to be used by intermediate ecoli nodes, i.e. nodes
- * which have children (ex: ec_node_seq(), ec_node_or(), ...). It fills an
+ * This function is to be used by intermediate ecoli nodes, i.e., nodes
+ * which have children (e.g., ec_node_seq(), ec_node_or(), ...). It fills an
  * existing ::ec_comp structure, passed by the parent node.
  *
  * @param node
@@ -240,13 +240,13 @@ struct ec_dict *ec_comp_get_attrs(const struct ec_comp *comp);
  * Create a new completion item, and add it into the completion
  * list. A completion item has a type, which can be:
  *
- * - EC_COMP_FULL: the item is fully completed (common case, used
+ * - ::EC_COMP_FULL - the item is fully completed (common case, used
  *   for instance in the str node)
- * - EC_COMP_PARTIAL: the item is only partially completed (this
+ * - ::EC_COMP_PARTIAL - the item is only partially completed (this
  *   happens rarely, for instance in the file node, when a completion
  *   goes up to the next slash).
- * - EC_COMP_UNKNOWN: the node detects a valid token, but does not
- *   how to complete it (ex: the int node).
+ * - ::EC_COMP_UNKNOWN - the node detects a valid token, but does not know
+ *   how to complete it (e.g., the int node).
  *
  * @param comp
  *   The current completion list.
@@ -337,13 +337,13 @@ const struct ec_comp_group *ec_comp_item_get_grp(const struct ec_comp_item *item
  * @param item
  *   The completion item.
  * @return
- *   The type of this item (EC_COMP_UNKNOWN, EC_COMP_PARTIAL or
- *   EC_COMP_FULL).
+ *   The type of this item (::EC_COMP_UNKNOWN, ::EC_COMP_PARTIAL or
+ *   ::EC_COMP_FULL).
  */
 enum ec_comp_type ec_comp_item_get_type(const struct ec_comp_item *item);
 
 /**
- * Get the node associated to a completion item.
+ * Get the node associated with a completion item.
  *
  * @param item
  *   The completion item.
@@ -372,11 +372,11 @@ int ec_comp_item_set_str(struct ec_comp_item *item, const char *str);
  *
  * The display string corresponds to what is displayed when listing the
  * possible completions. Some nodes like ec_node_file() change the default
- * value display the base name instead of the full path.
+ * value to display the base name instead of the full path.
  *
  * @param item
  *   The completion item to update.
- * @param str
+ * @param display
  *   The new display string.
  * @return
  *   0 on success, or -1 on error (errno is set).
@@ -393,7 +393,7 @@ int ec_comp_item_set_display(struct ec_comp_item *item, const char *display);
  *
  * @param item
  *   The completion item to update.
- * @param str
+ * @param completion
  *   The new completion string.
  * @return
  *   0 on success, or -1 on error (errno is set).
@@ -411,27 +411,27 @@ const struct ec_node *ec_comp_group_get_node(const struct ec_comp_group *grp);
 /**
  * Get the completion group parsing state.
  *
- * All items of a completion group are issued by the same node.
- * This function returns a pointer to this node.
+ * The parsing state contains the parsing result of the input data
+ * preceding the completion. All items of a completion group share the
+ * same parsing state.
  *
  * @param grp
  *   The completion group.
  * @return
- *   The node that issued the completion group.
+ *   The parsing state of the completion group.
  */
 const struct ec_pnode *ec_comp_group_get_pstate(const struct ec_comp_group *grp);
 
 /**
  * Get the completion group attributes.
  *
- * The parsing state contains the parsing result of the input data
- * preceding the completion. All items of a completion group share the
- * same parsing state.
+ * Arbitrary attributes (stored in a dictionary) can be attached to a
+ * completion group.
  *
-  * @param grp
+ * @param grp
  *   The completion group.
  * @return
- *   The parsing state of the completion group.
+ *   The attributes of the completion group.
  */
 const struct ec_dict *ec_comp_group_get_attrs(const struct ec_comp_group *grp);
 
@@ -441,7 +441,7 @@ const struct ec_dict *ec_comp_group_get_attrs(const struct ec_comp_group *grp);
  * This function is the default completion method for nodes that do
  * not define one.
  *
- * This helper adds a completion item of type EC_COMP_UNKNOWN if the
+ * This helper adds a completion item of type ::EC_COMP_UNKNOWN if the
  * input string vector contains one element, to indicate that everything
  * before the last element of the string vector has been parsed
  * successfully, but the node doesn't know how to complete the last
@@ -471,8 +471,8 @@ int ec_complete_unknown(
  * @param comp
  *   The completion list.
  * @param type
- *   A logical OR of flags among EC_COMP_UNKNOWN, EC_COMP_PARTIAL and
- *   EC_COMP_FULL, to select the type to match.
+ *   A logical OR of flags among ::EC_COMP_UNKNOWN, ::EC_COMP_PARTIAL and
+ *   ::EC_COMP_FULL, to select the type to match.
  * @return
  *   The number of matching items.
  */
@@ -486,25 +486,25 @@ size_t ec_comp_count(const struct ec_comp *comp, enum ec_comp_type type);
  * @param comp
  *   The completion list.
  * @param type
- *   A logical OR of flags among EC_COMP_UNKNOWN, EC_COMP_PARTIAL and
- *   EC_COMP_FULL, to select the type to iterate.
+ *   A logical OR of flags among ::EC_COMP_UNKNOWN, ::EC_COMP_PARTIAL and
+ *   ::EC_COMP_FULL, to select the type to iterate.
  * @return
  *   A completion item.
  */
 struct ec_comp_item *ec_comp_iter_first(const struct ec_comp *comp, enum ec_comp_type type);
 
 /**
- * Get the first completion item matching the type.
+ * Get the next completion item matching the type.
  *
  * Also see EC_COMP_FOREACH().
  *
- * @param comp
- *   The completion list.
+ * @param item
+ *   The current completion item.
  * @param type
- *   A logical OR of flags among EC_COMP_UNKNOWN, EC_COMP_PARTIAL and
- *   EC_COMP_FULL, to select the type to iterate.
+ *   A logical OR of flags among ::EC_COMP_UNKNOWN, ::EC_COMP_PARTIAL and
+ *   ::EC_COMP_FULL, to select the type to iterate.
  * @return
- *   A completion item.
+ *   The next completion item, or NULL if there is no more.
  */
 struct ec_comp_item *ec_comp_iter_next(struct ec_comp_item *item, enum ec_comp_type type);
 
@@ -516,8 +516,8 @@ struct ec_comp_item *ec_comp_iter_next(struct ec_comp_item *item, enum ec_comp_t
  * @param comp
  *   The completion list.
  * @param type
- *   A logical OR of flags among EC_COMP_UNKNOWN, EC_COMP_PARTIAL and
- *   EC_COMP_FULL, to select the type to iterate.
+ *   A logical OR of flags among ::EC_COMP_UNKNOWN, ::EC_COMP_PARTIAL and
+ *   ::EC_COMP_FULL, to select the type to iterate.
  */
 #define EC_COMP_FOREACH(item, comp, type)                                                          \
 	for (item = ec_comp_iter_first(comp, type); item != NULL;                                  \

--- a/include/ecoli/config.h
+++ b/include/ecoli/config.h
@@ -44,17 +44,17 @@ enum ec_config_flags {
  * Structure describing the format of a configuration value.
  *
  * This structure is used in a const array which is referenced by a
- * struct ec_config. Each entry of the array represents a key/value
+ * struct ::ec_config. Each entry of the array represents a key/value
  * storage of the configuration dictionary.
  */
 struct ec_config_schema {
 	const char *key; /**< The key string (NULL for list elts). */
 	const char *desc; /**< A description of the value. */
 	enum ec_config_type type; /**< Type of the value */
-	enum ec_config_flags flags; /**< Flags, see @ec_config_flags */
+	enum ec_config_flags flags; /**< Flags, see ::ec_config_flags. */
 
 	/** If type is dict or list, the schema of the dict or list
-	 * elements. Else must be NULL. */
+	 * elements. Otherwise, must be NULL. */
 	const struct ec_config_schema *subschema;
 };
 
@@ -64,7 +64,7 @@ TAILQ_HEAD(ec_config_list, ec_config);
  * Structure storing the configuration data.
  */
 struct ec_config {
-	/** type of value stored in the union */
+	/** Type of value stored in the union. */
 	enum ec_config_type type;
 
 	union {
@@ -83,14 +83,12 @@ struct ec_config {
 	TAILQ_ENTRY(ec_config) next;
 };
 
-/* schema */
-
 /**
  * Validate a configuration schema array.
  *
  * @param schema
  *   Pointer to the first element of the schema array. The array
- *   must be terminated by a sentinel entry (type == EC_CONFIG_TYPE_NONE).
+ *   must be terminated by a sentinel entry `{.type = EC_CONFIG_TYPE_NONE}`.
  * @return
  *   0 if the schema is valid, or -1 on error (errno is set).
  */
@@ -103,7 +101,7 @@ int ec_config_schema_validate(const struct ec_config_schema *schema);
  *   Output stream on which the dump will be sent.
  * @param schema
  *   Pointer to the first element of the schema array. The array
- *   must be terminated by a sentinel entry (type == EC_CONFIG_TYPE_NONE).
+ *   must be terminated by a sentinel entry `{.type == EC_CONFIG_TYPE_NONE}`.
  * @param name
  *   The name of the schema.
  */
@@ -112,11 +110,11 @@ void ec_config_schema_dump(FILE *out, const struct ec_config_schema *schema, con
 /**
  * Find a schema entry matching the key.
  *
- * Browse the schema array and lookup for the given key.
+ * Browse the schema array and look up the given key.
  *
  * @param schema
  *   Pointer to the first element of the schema array. The array
- *   must be terminated by a sentinel entry (type == EC_CONFIG_TYPE_NONE).
+ *   must be terminated by a sentinel entry `{.type == EC_CONFIG_TYPE_NONE}`.
  * @param key
  *   Schema key name.
  * @return
@@ -161,8 +159,6 @@ bool ec_config_key_is_reserved(const char *name);
  * Array of reserved key names.
  */
 extern const char *ec_config_reserved_keys[];
-
-/* config */
 
 /**
  * Get the type of the configuration.
@@ -298,10 +294,10 @@ ssize_t ec_config_count(const struct ec_config *config);
 int ec_config_validate(const struct ec_config *dict, const struct ec_config_schema *schema);
 
 /**
- * Set a value in a hash table configuration
+ * Set a value in a hash table configuration.
  *
  * @param dict
- *   A hash table configuration to validate.
+ *   The hash table configuration.
  * @param key
  *   The key to update.
  * @param value
@@ -318,7 +314,7 @@ int ec_config_dict_set(struct ec_config *dict, const char *key, struct ec_config
  * The element is freed and should not be accessed.
  *
  * @param dict
- *   A hash table configuration to validate.
+ *   The hash table configuration.
  * @param key
  *   The key of the configuration to delete.
  * @return
@@ -341,11 +337,13 @@ struct ec_config *ec_config_dict_get(const struct ec_config *config, const char 
  *
  * Example of use:
  *
- * for (config = ec_config_list_iter(list);
+ * @code{.c}
+ * for (config = ec_config_list_first(list);
  *	config != NULL;
  *	config = ec_config_list_next(list, config)) {
  *		...
  * }
+ * @endcode
  *
  * @param list
  *   The list configuration to iterate.

--- a/include/ecoli/dict.h
+++ b/include/ecoli/dict.h
@@ -90,7 +90,7 @@ int ec_dict_del(struct ec_dict *dict, const char *key);
 int ec_dict_set(struct ec_dict *dict, const char *key, void *val, ec_dict_elt_free_t free_cb);
 
 /**
- * Free a hash table an all its objects.
+ * Free a hash table and all its objects.
  *
  * @param dict
  *   The hash table.
@@ -108,7 +108,7 @@ void ec_dict_free(struct ec_dict *dict);
 size_t ec_dict_len(const struct ec_dict *dict);
 
 /**
- * Duplicate a hash table
+ * Duplicate a hash table.
  *
  * A reference counter is shared between the clones of
  * hash tables so that the objects are freed only when
@@ -136,6 +136,7 @@ void ec_dict_dump(FILE *out, const struct ec_dict *dict);
  *
  * The typical usage is as below:
  *
+ * @code{.c}
  *	for (iter = ec_dict_iter(dict);
  *	     iter != NULL;
  *	     iter = ec_dict_iter_next(iter)) {
@@ -143,6 +144,7 @@ void ec_dict_dump(FILE *out, const struct ec_dict *dict);
  *			ec_dict_iter_get_key(iter),
  *			ec_dict_iter_get_val(iter));
  *	}
+ * @endcode
  *
  * @param dict
  *   The hash table.
@@ -157,7 +159,7 @@ struct ec_dict_elt_ref *ec_dict_iter(const struct ec_dict *dict);
  * @param iter
  *   The hash table iterator.
  * @return
- *   An iterator element, or NULL there is no more element.
+ *   An iterator element, or NULL if there is no more element.
  */
 struct ec_dict_elt_ref *ec_dict_iter_next(struct ec_dict_elt_ref *iter);
 

--- a/include/ecoli/dict.h
+++ b/include/ecoli/dict.h
@@ -17,6 +17,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 
+/** Callback function for freeing dictionary elements. */
 typedef void (*ec_dict_elt_free_t)(void *);
 
 /** Dictionary (string key hash table). */

--- a/include/ecoli/editline.h
+++ b/include/ecoli/editline.h
@@ -15,13 +15,13 @@
 #pragma once
 
 #include <stdbool.h>
-
-#include <histedit.h>
+#include <stdio.h>
 
 struct ec_editline;
 struct ec_node;
 struct ec_pnode;
 struct ec_comp;
+struct editline;
 
 /**
  * A structure describing a contextual help.
@@ -140,7 +140,7 @@ void ec_editline_free(struct ec_editline *editline);
  * @param editline
  *   The pointer to the ec_editline structure.
  */
-EditLine *ec_editline_get_el(struct ec_editline *editline);
+struct editline *ec_editline_get_el(struct ec_editline *editline);
 
 /**
  * Get terminal width and height.
@@ -323,6 +323,6 @@ int ec_editline_interact(
  * @return
  *   An editline error code: CC_REFRESH, CC_ERROR, or CC_REDISPLAY.
  */
-int ec_editline_complete(EditLine *el, int c);
+int ec_editline_complete(struct editline *el, int c);
 
 /** @} */

--- a/include/ecoli/editline.h
+++ b/include/ecoli/editline.h
@@ -17,11 +17,13 @@
 #include <stdbool.h>
 #include <stdio.h>
 
-struct ec_editline;
 struct ec_node;
 struct ec_pnode;
 struct ec_comp;
 struct editline;
+
+/** Editline instance for interactive command line editing. */
+struct ec_editline;
 
 /**
  * A structure describing a contextual help.

--- a/include/ecoli/editline.h
+++ b/include/ecoli/editline.h
@@ -45,8 +45,9 @@ enum ec_editline_init_flags {
 	/**
 	 * Ask the terminal to not send signals (STOP, SUSPEND, ...). The
 	 * `ctrl-c`, `ctrl-z` will be interpreted as standard characters. An
-	 * action can be associated to these characters with:
+	 * action can be associated with these characters with:
 	 *
+	 * @code{.c}
 	 *	static int cb(EditLine *editline, int c) {
 	 *	{
 	 *		see editline documentation for details
@@ -56,6 +57,7 @@ enum ec_editline_init_flags {
 	 *		handle_error;
 	 *	if (el_set(el, EL_BIND, "^C", "ed-break", NULL))
 	 *		handle_error;
+	 * @endcode
 	 *
 	 * The default behavior (without this flag) is to let the signal pass: ctrl-c
 	 * will stop program and ctrl-z will suspend it.
@@ -63,8 +65,8 @@ enum ec_editline_init_flags {
 	EC_EDITLINE_DISABLE_SIGNALS = 1 << 0,
 
 	/**
-	 * Disable history. The default behavior creates an history with
-	 * EC_EDITLINE_HISTORY_SIZE entries. To change this value, use
+	 * Disable history. The default behavior creates a history with
+	 * ::EC_EDITLINE_HISTORY_SIZE entries. To change this value, use
 	 * ec_editline_set_history().
 	 */
 	EC_EDITLINE_DISABLE_HISTORY = 1 << 1,
@@ -73,10 +75,12 @@ enum ec_editline_init_flags {
 	 * Disable completion. The default behavior is to complete when
 	 * `?` or `<tab>` is hit. You can register your own callback with:
 	 *
+	 * @code{.c}
 	 *	if (el_set(el, EL_ADDFN, "ed-complete", "Complete buffer", callback))
 	 *		handle_error;
 	 *	if (el_set(el, EL_BIND, "^I", "ed-complete", NULL))
 	 *		handle_error;
+	 * @endcode
 	 *
 	 * The default used callback is ec_editline_complete().
 	 */
@@ -100,7 +104,7 @@ typedef int (*ec_editline_check_exit_cb_t)(void *opaque);
 /**
  * Create an editline instance with default behavior.
  *
- * It allocates and initializes an ec_editline structure, calls editline's
+ * It allocates and initializes an ::ec_editline structure, calls editline's
  * el_init(), and does the editline configuration according to given flags.
  *
  * After that, the user must call ec_editline_set_node() to attach the grammar
@@ -116,7 +120,7 @@ typedef int (*ec_editline_check_exit_cb_t)(void *opaque);
  * @param f_err
  *   The error stream to use.
  * @param flags
- *   Flags to customize initialization. See @ec_editline_init_flags.
+ *   Flags to customize initialization. See ::ec_editline_init_flags.
  * @return
  *   The allocated ec_editline structure, or NULL on error.
  */
@@ -132,15 +136,15 @@ struct ec_editline *ec_editline(
  * Free an editline structure allocated with ec_editline().
  *
  * @param editline
- *   The pointer to the ec_editline structure to free.
+ *   The pointer to the ::ec_editline structure to free.
  */
 void ec_editline_free(struct ec_editline *editline);
 
 /**
- * Return the wrapped editline instance attached to the ec_editline structure.
+ * Return the wrapped editline instance attached to the ::ec_editline structure.
  *
  * @param editline
- *   The pointer to the ec_editline structure.
+ *   The pointer to the ::ec_editline structure.
  */
 struct editline *ec_editline_get_el(struct ec_editline *editline);
 
@@ -148,14 +152,14 @@ struct editline *ec_editline_get_el(struct ec_editline *editline);
  * Get terminal width and height.
  *
  * @param editline
- *   The pointer to the ec_editline structure.
- * @params width
+ *   The pointer to the ::ec_editline structure.
+ * @param width
  *   The pointer where the number of columns is stored on success.
- * @params height
+ * @param height
  *   The pointer where the number of rows is stored on success.
  * @return
- *   0 on success, or -1 on error (in this case the value pointed by width and height are not
- *   modified).
+ *   0 on success, or -1 on error (in this case the value pointed by width and
+ *   height are not modified).
  */
 int ec_editline_term_size(
 	const struct ec_editline *editline,
@@ -171,9 +175,9 @@ int ec_editline_term_size(
  * attached as a string to nodes using a node attribute EC_EDITLINE_HELP_ATTR.
  *
  * @param editline
- *   The pointer to the ec_editline structure.
+ *   The pointer to the ::ec_editline structure.
  * @param node
- *   The pointer to the sh_lex ec_node to use as grammar.
+ *   The pointer to the sh_lex ::ec_node to use as grammar.
  * @return
  *   0 on success, or -1 on error. errno is set to EINVAL if the node is not
  *   of type sh_lex.
@@ -184,21 +188,21 @@ int ec_editline_set_node(struct ec_editline *editline, const struct ec_node *nod
  * Return the ecoli node attached to the editline structure.
  *
  * @param editline
- *   The pointer to the ec_editline structure.
+ *   The pointer to the ::ec_editline structure.
  * @return
- *   The pointer to the ec_node.
+ *   The pointer to the ::ec_node.
  */
 const struct ec_node *ec_editline_get_node(const struct ec_editline *editline);
 
 /**
  * Change the history size.
  *
- * The default behavior is to have an history whose size
- * is EC_EDITLINE_HISTORY_SIZE. This can be changed with this
+ * The default behavior is to have a history whose size
+ * is ::EC_EDITLINE_HISTORY_SIZE. This can be changed with this
  * function.
  *
  * @param editline
- *   The pointer to the ec_editline structure.
+ *   The pointer to the ::ec_editline structure.
  * @param hist_size
  *   The desired size of the history.
  * @param hist_file
@@ -212,7 +216,7 @@ int ec_editline_set_history(struct ec_editline *editline, size_t hist_size, cons
  * Set editline prompt.
  *
  * @param editline
- *   The pointer to the ec_editline structure.
+ *   The pointer to the ::ec_editline structure.
  * @param prompt
  *   The prompt string to use.
  * @return
@@ -224,6 +228,7 @@ int ec_editline_set_prompt(struct ec_editline *editline, const char *prompt);
  * Set editline escaped prompt.
  *
  * From el_set(3):
+ *
  * If the start/stop delim character is found in the prompt, the character
  * itself is not printed, but characters after it are printed directly to the
  * terminal without affecting the state of the current line. A subsequent second
@@ -234,7 +239,7 @@ int ec_editline_set_prompt(struct ec_editline *editline, const char *prompt);
  * character in the prompt.
  *
  * @param editline
- *   The pointer to the ec_editline structure.
+ *   The pointer to the ::ec_editline structure.
  * @param prompt
  *   The prompt string to use.
  * @param delim
@@ -248,7 +253,7 @@ int ec_editline_set_prompt_esc(struct ec_editline *editline, const char *prompt,
  * Get the current edited line.
  *
  * @param editline
- *   The pointer to the ec_editline structure.
+ *   The pointer to the ::ec_editline structure.
  * @param trim_after_cursor
  *   If true, remove all characters starting from cursor (included).
  * @return
@@ -264,7 +269,7 @@ char *ec_editline_curline(const struct ec_editline *editline, bool trim_after_cu
  * and adds it to the history.
  *
  * @param editline
- *   The pointer to the ec_editline structure.
+ *   The pointer to the ::ec_editline structure.
  * @return
  *   An allocated string containing the edited line, that must be freed by the
  *   caller using free().
@@ -278,10 +283,10 @@ char *ec_editline_gets(struct ec_editline *editline);
  * the grammar node on success.
  *
  * @param editline
- *   The pointer to the ec_editline structure.
+ *   The pointer to the ::ec_editline structure.
  * @return
- *   An allocated ec_pnode containing the parse result. It must be freed by the
- *   using using ec_pnode_free(). Return NULL on error.
+ *   An allocated ::ec_pnode containing the parse result. It must be freed by the
+ *   caller using ec_pnode_free(). Return NULL on error.
  */
 struct ec_pnode *ec_editline_parse(struct ec_editline *editline);
 
@@ -290,14 +295,14 @@ struct ec_pnode *ec_editline_parse(struct ec_editline *editline);
  *
  * Run the command line, parsing and completing commands on demand. When a
  * command is parsed successfully, invoke the callback attached to the grammar
- * node as a EC_INTERACT_CB_ATTR attribute. The callback type must be
- * @ec_interact_command_cb_t.
+ * node as a ::EC_INTERACT_CB_ATTR attribute. The callback type must be
+ * ::ec_interact_command_cb_t.
  *
  * On EOF, or if check_exit() function returns true, exit from the interactive
  * loop.
  *
  * @param editline
- *   The pointer to the ec_editline structure.
+ *   The pointer to the ::ec_editline structure.
  * @param check_exit_cb
  *   Optional function pointer executed before each loop iteration to check if
  *   loop should be exited (when the function return true).
@@ -315,8 +320,8 @@ int ec_editline_interact(
 /**
  * Default completion callback used by editline.
  *
- * It displays the list of completions with <tab>, and a contextual help
- * with <?>.
+ * It displays the list of completions with TAB, and a contextual help
+ * with '?'.
  *
  * @param el
  *   The pointer to libedit Editline structure.

--- a/include/ecoli/htable.h
+++ b/include/ecoli/htable.h
@@ -105,7 +105,7 @@ int ec_htable_set(
 );
 
 /**
- * Free a hash table an all its objects.
+ * Free a hash table and all its objects.
  *
  * @param htable
  *   The hash table.
@@ -123,7 +123,7 @@ void ec_htable_free(struct ec_htable *htable);
 size_t ec_htable_len(const struct ec_htable *htable);
 
 /**
- * Duplicate a hash table
+ * Duplicate a hash table.
  *
  * A reference counter is shared between the clones of
  * hash tables so that the objects are freed only when
@@ -161,6 +161,7 @@ void ec_htable_dump(FILE *out, const struct ec_htable *htable);
  *
  * The typical usage is as below:
  *
+ * @code{.c}
  *	for (iter = ec_htable_iter(htable);
  *	     iter != NULL;
  *	     iter = ec_htable_iter_next(iter)) {
@@ -168,11 +169,12 @@ void ec_htable_dump(FILE *out, const struct ec_htable *htable);
  *			ec_htable_iter_get_key(iter),
  *			ec_htable_iter_get_val(iter));
  *	}
+ * @endcode
  *
  * @param htable
  *   The hash table.
  * @return
- *   An iterator element, or NULL if the dict is empty.
+ *   An iterator element, or NULL if the htable is empty.
  */
 struct ec_htable_elt_ref *ec_htable_iter(const struct ec_htable *htable);
 
@@ -182,7 +184,7 @@ struct ec_htable_elt_ref *ec_htable_iter(const struct ec_htable *htable);
  * @param iter
  *   The hash table iterator.
  * @return
- *   An iterator element, or NULL there is no more element.
+ *   An iterator element, or NULL if there is no more element.
  */
 struct ec_htable_elt_ref *ec_htable_iter_next(struct ec_htable_elt_ref *iter);
 

--- a/include/ecoli/htable.h
+++ b/include/ecoli/htable.h
@@ -18,9 +18,13 @@
 #include <stdint.h>
 #include <stdio.h>
 
+/** Callback function for freeing hash table elements. */
 typedef void (*ec_htable_elt_free_t)(void *);
 
+/** Hash table with arbitrary key types. */
 struct ec_htable;
+
+/** Hash table element reference for iteration. */
 struct ec_htable_elt_ref;
 
 /**

--- a/include/ecoli/init.h
+++ b/include/ecoli/init.h
@@ -22,7 +22,7 @@
  *
  * Do not use priorities < 100 for application code; internal libecoli
  * components may depend on those priorities and using them can lead to
- * uninitialized state, crashes, or undefined behaviour.
+ * uninitialized state, crashes, or undefined behavior.
  */
 #define EC_INIT_REGISTER(t)                                                                        \
 	static void ec_init_init_##t(void);                                                        \
@@ -44,7 +44,7 @@ typedef void(ec_exit_t)(void);
 TAILQ_HEAD(ec_init_list, ec_init);
 
 /**
- * A structure describing a test case.
+ * A structure describing initialization callbacks.
  */
 struct ec_init {
 	TAILQ_ENTRY(ec_init) next; /**< Next in list. */
@@ -57,7 +57,7 @@ struct ec_init {
  * Register an initialization function.
  *
  * @param test
- *   A pointer to a ec_init structure to be registered.
+ *   A pointer to an ::ec_init structure to be registered.
  */
 void ec_init_register(struct ec_init *test);
 

--- a/include/ecoli/init.h
+++ b/include/ecoli/init.h
@@ -3,8 +3,10 @@
  */
 
 /**
- * @addtogroup ecoli_nodes
+ * @defgroup ecoli_init Initialization
  * @{
+ *
+ * @brief Library initialization and cleanup functions.
  */
 
 #pragma once

--- a/include/ecoli/interact.h
+++ b/include/ecoli/interact.h
@@ -44,7 +44,7 @@ struct ec_interact_help {
 #define EC_INTERACT_DESC_ATTR "_desc"
 
 /**
- * Type of callback attached with EC_INTERACT_CB_ATTR attribute.
+ * Type of callback attached with ::EC_INTERACT_CB_ATTR attribute.
  */
 typedef int (*ec_interact_command_cb_t)(const struct ec_pnode *);
 
@@ -56,7 +56,7 @@ typedef int (*ec_interact_command_cb_t)(const struct ec_pnode *);
  * @param matches_out
  *   The pointer where the matches array will be returned.
  * @param type_mask
- *   The mask of completion types to return (ex: EC_COMP_FULL | EC_COMP_PARTIAL)
+ *   The mask of completion types to return (e.g., `EC_COMP_FULL | EC_COMP_PARTIAL`).
  * @return
  *   The size of the array on success (>= 0), or -1 on error.
  */
@@ -81,7 +81,7 @@ void ec_interact_free_completions(char **matches, size_t n);
  *
  * @param out
  *   The pointer to the output stream.
- * @params width
+ * @param width
  *   The number of columns on terminal.
  * @param matches
  *   The string array of matches to display.
@@ -98,9 +98,10 @@ int ec_interact_print_cols(FILE *out, unsigned int width, char const *const *mat
  * @param cmpl
  *   The completion object containing all the completion items.
  * @return
- *   An allocated string to be appended to the current line (must be freed by the caller using
- *   free()). This string can be empty if there is no completion or if completions start with a
- *   different letter. Return NULL on error.
+ *   An allocated string to be appended to the current line (must be freed by
+ *   the caller using free()). This string can be empty if there is no
+ *   completion or if completions start with a different letter. Return NULL on
+ *   error.
  */
 char *ec_interact_append_chars(const struct ec_comp *cmpl);
 
@@ -127,7 +128,7 @@ ssize_t ec_interact_get_helps(
  *
  * @param out
  *   The pointer to the output stream.
- * @params width
+ * @param width
  *   The number of columns on terminal.
  * @param helps
  *   The helps array returned by ec_interact_get_helps().
@@ -183,7 +184,7 @@ ssize_t ec_interact_get_error_helps(
  *
  * @param out
  *   The pointer to the output stream.
- * @params width
+ * @param width
  *   The number of columns on terminal.
  * @param line
  *   The line used to generate the error helps.
@@ -208,7 +209,7 @@ int ec_interact_print_error_helps(
 /**
  * Set help on a grammar node.
  *
- * Set the node attribute EC_INTERACT_HELP_ATTR on the node, containing the
+ * Set the node attribute ::EC_INTERACT_HELP_ATTR on the node, containing the
  * given string. It is used by the ec_interact functions to display contextual
  * helps on completion or parsing error.
  *
@@ -224,7 +225,7 @@ int ec_interact_set_help(struct ec_node *node, const char *help);
 /**
  * Set callback function on a grammar node.
  *
- * Set the node attribute EC_INTERACT_CB_ATTR on the node, containing the
+ * Set the node attribute ::EC_INTERACT_CB_ATTR on the node, containing the
  * pointer to a function invoked on successful parsing.
  *
  * @param node
@@ -239,7 +240,7 @@ int ec_interact_set_callback(struct ec_node *node, ec_interact_command_cb_t cb);
 /**
  * Set short description of a grammar node.
  *
- * Set the node attribute EC_INTERACT_DESC_ATTR on the node, containing the
+ * Set the node attribute ::EC_INTERACT_DESC_ATTR on the node, containing the
  * given string. It is used by the ec_interact functions to display the short
  * description of the contextual help, overriding the value provided by
  * ec_node_desc().
@@ -256,9 +257,9 @@ int ec_interact_set_desc(struct ec_node *node, const char *desc);
 /**
  * Get callback attached to a parse tree.
  *
- * This function browses the parse tree and try to find an attribute EC_INTERACT_CB_ATTR attached to
- * a grammar node referenced in the tree. Return the value of this attribute, which is a function
- * pointer.
+ * This function browses the parse tree and try to find an attribute
+ * ::EC_INTERACT_CB_ATTR attached to a grammar node referenced in the tree.
+ * Return the value of this attribute, which is a function pointer.
  *
  * @param parse
  *   The parsed tree.

--- a/include/ecoli/log.h
+++ b/include/ecoli/log.h
@@ -8,11 +8,11 @@
  *
  * @brief Log API
  *
- * This file provide logging helpers:
+ * This file provides logging helpers:
  * - logging functions, supporting printf-like format
- * - several debug level (similar to syslog)
+ * - several debug levels (similar to syslog)
  * - named log types
- * - redirection of log to a user functions (default logs nothing)
+ * - redirection of logs to user functions (default logs nothing)
  */
 
 #pragma once
@@ -40,7 +40,7 @@ enum ec_log_level {
 /**
  * A structure describing a log type.
  *
- * It is defined as a static structure by the EC_LOG_TYPE_REGISTER() macro.
+ * It is defined as a static structure by the ::EC_LOG_TYPE_REGISTER() macro.
  */
 struct ec_log_type {
 	TAILQ_ENTRY(ec_log_type) next; /**< Next in list. */
@@ -55,7 +55,7 @@ struct ec_log_type {
  * This macro defines a function that will be called at startup (using
  * the "constructor" attribute). This function registers the named type
  * passed as argument, and sets a static global variable
- * "ec_log_local_type". This variable is used as the default log type
+ * `ec_log_local_type`. This variable is used as the default log type
  * for this file when using EC_LOG() or EC_VLOG().
  *
  * This macro can be present several times in a file. In this case, the
@@ -81,7 +81,7 @@ struct ec_log_type {
  * User log function type.
  *
  * It is advised that a user-defined log function drops all messages
- * that are at least as critical as ec_log_level_get(), as done by the
+ * that are less critical than ec_log_level_get(), as done by the
  * default handler.
  *
  * @param type
@@ -114,7 +114,7 @@ int ec_log_fct_register(ec_log_t usr_log, void *opaque);
  * Register a named log type.
  *
  * Register a new log type, which is identified by its name. The
- * function returns a log identifier associated to the log name. If the
+ * function returns a log identifier associated with the log name. If the
  * name is already registered, the function just returns its identifier.
  *
  * @param type
@@ -126,12 +126,12 @@ int ec_log_fct_register(ec_log_t usr_log, void *opaque);
 int ec_log_type_register(struct ec_log_type *type);
 
 /**
- * Return the log name associated to the log type identifier.
+ * Return the log name associated with the log type identifier.
  *
  * @param type
  *   The log type identifier.
  * @return
- *   The name associated to the log type, or "unknown". It always return
+ *   The name associated with the log type, or "unknown". It always returns
  *   a valid string (never NULL).
  */
 const char *ec_log_name(int type);
@@ -170,8 +170,8 @@ int ec_vlog(int type, enum ec_log_level level, const char *format, va_list ap);
 /**
  * Log a formatted string using the local log type.
  *
- * This macro requires that a log type is previously register with
- * EC_LOG_TYPE_REGISTER() since it uses the "ec_log_local_type"
+ * This macro requires that a log type is previously registered with
+ * ::EC_LOG_TYPE_REGISTER() since it uses the `ec_log_local_type`
  * variable.
  *
  * @param level
@@ -186,8 +186,8 @@ int ec_vlog(int type, enum ec_log_level level, const char *format, va_list ap);
 /**
  * Log a formatted string using the local log type.
  *
- * This macro requires that a log type is previously register with
- * EC_LOG_TYPE_REGISTER() since it uses the "ec_log_local_type"
+ * This macro requires that a log type is previously registered with
+ * ::EC_LOG_TYPE_REGISTER() since it uses the `ec_log_local_type`
  * variable.
  *
  * @param level
@@ -227,8 +227,6 @@ int ec_log_default_cb(int type, enum ec_log_level level, void *opaque, const cha
  * This level is used by the default log handler, ec_log_default_cb().
  * All messages that are at least as critical as the default level are
  * displayed.
- *
- * It is advised
  *
  * @param level
  *   The log level to be set.

--- a/include/ecoli/log.h
+++ b/include/ecoli/log.h
@@ -23,6 +23,9 @@
 
 #include <ecoli/assert.h>
 
+/**
+ * Log levels, from most critical to least critical.
+ */
 enum ec_log_level {
 	EC_LOG_EMERG = 0, /**< system is unusable */
 	EC_LOG_ALERT = 1, /**< action must be taken immediately */

--- a/include/ecoli/node.h
+++ b/include/ecoli/node.h
@@ -8,42 +8,47 @@
  *
  * @brief Libecoli grammar nodes.
  *
- * The grammar node is a main structure of the ecoli library, used to define
- * how to match and complete the input tokens. A node is a generic object
- * that implements:
- * - a parse(node, input) method: check if an input matches
- * - a complete(node, input) method: return possible completions for
- *   a given input
+ * The grammar node is a main structure of the ecoli library, used to define how
+ * to match and complete the input tokens. A node is a generic object that
+ * implements:
+ *
+ * - a `parse(node, input)` method: check if an input matches
+ * - a `complete(node, input)` method: return possible completions for a given
+ *   input
  * - some other methods to initialize, free, ...
  *
- * One basic example is the string node (ec_node_str). A node
- * ec_node_str("foo") will match any token list starting with "foo",
- * for example:
- * - ["foo"]
- * - ["foo", "bar", ...]
- * But will not match:
- * - []
- * - ["bar", ...]
+ * One basic example is the string node (ec_node_str()). A node
+ * `ec_node_str("foo")` will match any token list starting with `"foo"`, for
+ * example:
  *
- * A node ec_node_str("foo") will complete with "foo" if the input
- * contains one token, with the same beginning than "foo":
- * - [""]
- * - ["f"]
- * - ["fo"]
- * - ["foo"]
+ * - `["foo"]`
+ * - `["foo", "bar", ...]`
+ * But will not match:
+ * - `[]`
+ * - `["bar", ...]`
+ *
+ * A node `ec_node_str("foo")` will complete with `"foo"` if the input contains
+ * one token, with the same beginning as `"foo"`:
+ *
+ * - `[""]`
+ * - `["f"]`
+ * - `["fo"]`
+ * - `["foo"]`
+ *
  * But it will not complete:
- * - []
- * - ["bar"]
- * - ["f", ""]
- * - ["", "f"]
+ *
+ * - `[]`
+ * - `["bar"]`
+ * - `["f", ""]`
+ * - `["", "f"]`
  *
  * A node can have child nodes. For instance, a sequence node
- * ec_node_seq(ec_node_str("foo"), ec_node_str("bar")) will match
- * a sequence: ["foo", "bar"].
+ * `ec_node_seq(ec_node_str("foo"), ec_node_str("bar"))` will match a sequence:
+ * `["foo", "bar"]`.
  *
- * Note: at some places in the documentation and the code, we may talk
- * about the grammar tree, but as loops are allowed, we should instead
- * talk about grammar graph.
+ * Note: at some places in the documentation and the code, we may talk about the
+ * grammar tree, but as loops are allowed, we should instead talk about grammar
+ * graph.
  */
 
 #pragma once
@@ -74,11 +79,11 @@ struct ec_config_schema;
 /**
  * Register a node type at library load.
  *
- * The node type is registered in a function that has the the
+ * The node type is registered in a function that has the
  * constructor attribute: the function is called at library load.
  *
  * @param t
- *   The name of the ec_node_type structure variable.
+ *   The name of the ::ec_node_type structure variable.
  */
 #define EC_NODE_TYPE_REGISTER(t)                                                                   \
 	static void ec_node_init_##t(void);                                                        \
@@ -91,7 +96,7 @@ struct ec_config_schema;
 /**
  * Register a node type at library load, overriding previous registration.
  *
- * The node type is registered in a function that has the the
+ * The node type is registered in a function that has the
  * constructor attribute: the function is called at library load.
  *
  * Be careful when using this macro, as the last type with a given name
@@ -99,7 +104,7 @@ struct ec_config_schema;
  * predict, especially within the same binary.
  *
  * @param t
- *   The name of the ec_node_type structure variable.
+ *   The name of the ::ec_node_type structure variable.
  */
 #define EC_NODE_TYPE_REGISTER_OVERRIDE(t)                                                          \
 	static void ec_node_init_##t(void);                                                        \
@@ -112,16 +117,16 @@ struct ec_config_schema;
 /**
  * Function type used to configure a node.
  *
- * The function pointer is not called directly, the helper ec_node_set_config() should be used
- * instead.
+ * The function pointer is not called directly, the helper ec_node_set_config()
+ * should be used instead.
  *
- * The configuration passed to this function pointer is valid, i.e. ec_config_validate() returned 0
- * on it.
+ * The configuration passed to this function pointer is valid, i.e.
+ * ec_config_validate() returned 0 on it.
  *
- * This function provided by a node type is supposed to do additional checks to the configuration
- * and store private, if needed. If it returns 0, ec_node_set_config() stores the generic
- * configuration in the node. The function can just return 0 if nothing needs to be stored in
- * private data.
+ * This function provided by a node type is supposed to do additional checks on
+ * the configuration and store private data, if needed. If it returns 0,
+ * ec_node_set_config() stores the generic configuration in the node. The
+ * function can just return 0 if nothing needs to be stored in private data.
  *
  * @param node
  *   The node to configure.
@@ -152,7 +157,7 @@ typedef int (*ec_node_set_config_t)(struct ec_node *node, const struct ec_config
  *   The string vector to be parsed.
  * @return
  *   On success, return the number of consumed items in the string vector
- *   (can be 0) or EC_PARSE_NOMATCH if the node cannot parse the string
+ *   (can be 0) or ::EC_PARSE_NOMATCH if the node cannot parse the string
  *   vector. On error, a negative value is returned and errno is set.
  */
 typedef int (*ec_parse_t)(
@@ -170,7 +175,7 @@ typedef int (*ec_parse_t)(
  *
  * This function completes the last element of the string vector.
  * For instance, node.type->complete(node, comp, ["ls"]) will
- * list all commands that starts with "ls", while
+ * list all commands that start with "ls", while
  * node.type->complete(node, comp, ["ls", ""]) will list all
  * possible values for the next argument.
  *
@@ -186,8 +191,8 @@ typedef int (*ec_parse_t)(
  *   do a more complex job (parsing strvec).
  *
  * A node that does not provide any method for the completion
- * will fallback to ec_complete_unknown(): this helper returns
- * a completion item of type EC_COMP_UNKNOWN, just to indicate
+ * will fall back to ec_complete_unknown(): this helper returns
+ * a completion item of type ::EC_COMP_UNKNOWN, just to indicate
  * that everything before the last element of the string vector
  * has been parsed successfully, but we don't know how to
  * complete the last element.
@@ -226,7 +231,7 @@ typedef int (*ec_complete_t)(
  * default behavior is to return the node type name inside `<>`, for
  * instance `<int>`. The string node type implements this method to
  * return the string value. An integer node could implement it
- * to return its range (ex: "1..10").
+ * to return its range (e.g., "1..10").
  *
  * The returned value is a pointer that must be freed by
  * the caller with free().
@@ -275,7 +280,7 @@ typedef void (*ec_node_free_priv_t)(struct ec_node *);
 typedef size_t (*ec_node_get_children_count_t)(const struct ec_node *);
 
 /**
- * Count the number of node children.
+ * Get the i-th child node.
  *
  * This function pointer should not be called directly. The
  * ec_node_get_child() helper should be used instead.
@@ -308,7 +313,7 @@ struct ec_node_type {
 	TAILQ_ENTRY(ec_node_type) next; /**< Next in list. */
 	const char *name; /**< Node type name. */
 	/** Configuration schema array, must be terminated by a sentinel
-	 *  (.type = EC_CONFIG_TYPE_NONE). */
+	 *  `{.type = EC_CONFIG_TYPE_NONE}`. */
 	const struct ec_config_schema *schema;
 	size_t size; /**< Size of private area */
 	ec_node_set_config_t set_config; /**< Validate and set configuration. */
@@ -328,15 +333,16 @@ struct ec_node_type {
 TAILQ_HEAD(ec_node_type_list, ec_node_type);
 
 /**
- * The list of registered node types. Must not be modified by user, except at initialization using
- * the EC_NODE_TYPE_REGISTER() or EC_NODE_TYPE_REGISTER_OVERRIDE() macros.
+ * The list of registered node types. Must not be modified by user, except at
+ * initialization using the EC_NODE_TYPE_REGISTER() or
+ * EC_NODE_TYPE_REGISTER_OVERRIDE() macros.
  */
 extern struct ec_node_type_list node_type_list;
 
 /**
  * Register a node type.
  *
- * The name of the type being registered is a uniq identifier. However,
+ * The name of the type being registered is a unique identifier. However,
  * it is possible to force the registration of a type with an existing
  * name by setting "override" to true. Note that the initial type is not
  * removed from the list, instead the new one is added before in the
@@ -362,7 +368,7 @@ int ec_node_type_register(struct ec_node_type *type, bool override);
 const struct ec_node_type *ec_node_type_lookup(const char *name);
 
 /**
- * Dump registered log types.
+ * Dump registered node types.
  *
  * @param out
  *   The stream where the dump is sent.
@@ -391,7 +397,7 @@ const struct ec_config_schema *ec_node_type_schema(const struct ec_node_type *ty
 const char *ec_node_type_name(const struct ec_node_type *type);
 
 /**
- * Create a new node from a known type is known
+ * Create a new node when the type is known.
  *
  * This function is typically called from the node constructor.
  *
@@ -407,8 +413,8 @@ struct ec_node *ec_node_from_type(const struct ec_node_type *type, const char *i
 /**
  * Create a new node from its type name.
  *
- * This function is typically called from user code, for node types that do not provide a specific
- * constructor.
+ * This function is typically called from user code, for node types that do not
+ * provide a specific constructor.
  *
  * @param typename
  *   The type name of the node to create.
@@ -422,20 +428,22 @@ struct ec_node *ec_node(const char *typename, const char *id);
 /**
  * Clone a grammar node.
  *
- * This function takes a reference to the node. If ec_node_free() is later called on this node, it
- * will decrease only the reference. The free is effective when the reference count reaches 0. The
- * reference counter is initialized to 1 at node creation.
+ * This function takes a reference to the node. If ec_node_free() is later
+ * called on this node, it will decrease only the reference. The free is
+ * effective when the reference count reaches 0. The reference counter is
+ * initialized to 1 at node creation.
  *
  * @param node
  *   The node to clone.
  * @return
- *   The pointer to the cloned node, always equal to the parameter. It returns NULL if the parameter
- *   was NULL: in this case, nothing is done.
+ *   The pointer to the cloned node, always equal to the parameter. It returns
+ *   NULL if the parameter was NULL: in this case, nothing is done.
  */
 struct ec_node *ec_node_clone(struct ec_node *node);
 
 /**
- * Decrement node reference counter and free the node if it is the last reference.
+ * Decrement node reference counter and free the node if it is the last
+ * reference.
  *
  * @param node
  *   The grammar node to free.
@@ -447,16 +455,16 @@ void ec_node_free(struct ec_node *node);
  *
  * For a node that supports generic configuration, set its configuration.
  *
- * After a call to this function, the config is owned by the node and must not be used by the caller
- * anymore.
+ * After a call to this function, the config is owned by the node and must not
+ * be used by the caller anymore.
  *
  * @param node
  *   The grammar node to configure.
  * @param config
  *   The configuration to apply on the node.
  * @return
- *   0 on success, or a negative value on error (in this case the config passed as parameter is
- *   freed).
+ *   0 on success, or a negative value on error (in this case the config passed
+ *   as parameter is freed).
  */
 int ec_node_set_config(struct ec_node *node, struct ec_config *config);
 
@@ -492,7 +500,7 @@ size_t ec_node_get_children_count(const struct ec_node *node);
  * @param child
  *   The pointer where the child node pointer will be stored on success.
  * @return
- *   The number of children.
+ *   0 on success, -1 on error.
  */
 int ec_node_get_child(const struct ec_node *node, size_t i, struct ec_node **child);
 
@@ -509,8 +517,8 @@ const struct ec_node_type *ec_node_type(const struct ec_node *node);
 /**
  * Get the attributes dict of the node.
  *
- * A user can add any attribute to a node. The attributes keys starting with an underscore are
- * reserved.
+ * A user can add any attribute to a node. The attributes keys starting with an
+ * underscore are reserved.
  *
  * @param node
  *   The grammar node.
@@ -535,8 +543,8 @@ const char *ec_node_id(const struct ec_node *node);
  * @param node
  *   The grammar node.
  * @return
- *   An allocated string containing the node short description that must be freed by the
- *   caller. Return NULL on error.
+ *   An allocated string containing the node short description that must be
+ *   freed by the caller. Return NULL on error.
  */
 char *ec_node_desc(const struct ec_node *node);
 
@@ -553,12 +561,12 @@ void ec_node_dump(FILE *out, const struct ec_node *node);
 /**
  * Find a node from its identifier string.
  *
- * Browse the tree using pre-order depth traversal, and return the first node that matches the given
- * identifier.
+ * Browse the tree using pre-order depth traversal, and return the first node
+ * that matches the given identifier.
  *
  * @param node
  *   The grammar tree.
- * @param node
+ * @param id
  *   The identifier to match.
  * @return
  *   A node matching the identifier.
@@ -568,39 +576,47 @@ struct ec_node *ec_node_find(struct ec_node *node, const char *id);
 /**
  * Create an iterator on a grammar tree.
  *
- * A grammar tree is actually not really a tree, it is an oriented graph where loop can exist. For
- * this reason, it is not possible to iterate the grammar graph without storing somewhere the list
- * of browsed nodes in order to break loops.
+ * A grammar tree is actually not really a tree, it is an oriented graph where
+ * loops can exist. For this reason, it is not possible to iterate the grammar
+ * graph without storing somewhere the list of browsed nodes in order to break
+ * loops.
  *
- * Another property of grammar graphs is that the same node can appear several times at different
- * places in the graph, having a different parent. These kind of nodes will be iterated only once.
+ * Another property of grammar graphs is that the same node can appear several
+ * times at different places in the graph, having a different parent. This kind
+ * of node will be iterated only once.
  *
  * The typical use is:
  *
+ * @code{.c}
  *	struct ec_node_iter *iter_root, *iter;
+ *
  *	iter_root = ec_node_iter(node);
  *	if (iter_root == NULL)
  *		goto fail;
- *	for (iter = iter_root; iter != NULL; iter = ec_node_iter_next(iter_root, iter, true)) {
+ *
+ *	for (iter = iter_root; iter != NULL;
+ *	     iter = ec_node_iter_next(iter_root, iter, true)) {
  *		do_something_with(ec_node_iter_get_node(iter));
  *	}
- *	ec_node_iter_free(iter_root);
  *
- * Technically, this function builds a tree from the the grammar graph. Each node of this tree
- * references a node of the grammar graph.
+ *	ec_node_iter_free(iter_root);
+ * @endcode
+ *
+ * Technically, this function builds a tree from the grammar graph. Each node of
+ * this tree references a node of the grammar graph.
  *
  * @param node
  *   The grammar graph to iterate
  * @return
- *   The grammar graph iterator on success, that must be freed using ec_node_iter_free(). Return
- *   NULL on error.
+ *   The grammar graph iterator on success, that must be freed using
+ *   ec_node_iter_free(). Return NULL on error.
  */
 struct ec_node_iter *ec_node_iter(struct ec_node *node);
 
 /**
  * Iterate to the next node.
  *
- * See @ec_node_iter().
+ * See ec_node_iter().
  *
  * @param root
  *   The iterator returned by ec_node_iter().
@@ -638,7 +654,8 @@ struct ec_node *ec_node_iter_get_node(struct ec_node_iter *iter);
  * @param iter
  *   The iterator node.
  * @return
- *   The parent of the iterator node in the iterator tree. Return NULL if it's the root.
+ *   The parent of the iterator node in the iterator tree. Return NULL if it's
+ *   the root.
  */
 struct ec_node_iter *ec_node_iter_get_parent(struct ec_node_iter *iter);
 

--- a/include/ecoli/node_any.h
+++ b/include/ecoli/node_any.h
@@ -3,8 +3,11 @@
  */
 
 /**
- * @addtogroup ecoli_nodes
+ * @defgroup ecoli_node_any Any node
+ * @ingroup ecoli_nodes
  * @{
+ *
+ * @brief A node that matches any single token.
  */
 
 #pragma once

--- a/include/ecoli/node_bypass.h
+++ b/include/ecoli/node_bypass.h
@@ -12,7 +12,7 @@
 #include <ecoli/node.h>
 
 /**
- * A node that does nothing else than calling the child node.
+ * A node that does nothing other than calling the child node.
  * It can be helpful to build loops in a node graph.
  */
 struct ec_node *ec_node_bypass(const char *id, struct ec_node *node);

--- a/include/ecoli/node_bypass.h
+++ b/include/ecoli/node_bypass.h
@@ -3,8 +3,11 @@
  */
 
 /**
- * @addtogroup ecoli_nodes
+ * @defgroup ecoli_node_bypass Bypass node
+ * @ingroup ecoli_nodes
  * @{
+ *
+ * @brief A pass-through node useful for building graph loops.
  */
 
 #pragma once

--- a/include/ecoli/node_cmd.h
+++ b/include/ecoli/node_cmd.h
@@ -11,6 +11,19 @@
 
 #include <ecoli/node.h>
 
+/**
+ * Create a command node from a format string.
+ *
+ * The format string describes a command grammar using a simple syntax.
+ * Child nodes are passed as variadic arguments and referenced by name
+ * in the format string.
+ *
+ * Example:
+ *
+ * @code{.c}
+ * EC_NODE_CMD("mycmd", "show NAME", ec_node_str("NAME", NULL));
+ * @endcode
+ */
 #define EC_NODE_CMD(args...) __ec_node_cmd(args, EC_VA_END)
 
 struct ec_node *__ec_node_cmd(const char *id, const char *cmd_str, ...);

--- a/include/ecoli/node_cmd.h
+++ b/include/ecoli/node_cmd.h
@@ -3,8 +3,11 @@
  */
 
 /**
- * @addtogroup ecoli_nodes
+ * @defgroup ecoli_node_cmd Command node
+ * @ingroup ecoli_nodes
  * @{
+ *
+ * @brief A node that parses commands using a format string.
  */
 
 #pragma once

--- a/include/ecoli/node_cond.h
+++ b/include/ecoli/node_cond.h
@@ -21,7 +21,7 @@ struct ec_node;
  * @param id
  *   The node identifier.
  * @param cond_str
- *   The condition string. This is an function-based expression.
+ *   The condition string. This is a function-based expression.
  * @param child
  *   The ecoli child node.
  * @return

--- a/include/ecoli/node_cond.h
+++ b/include/ecoli/node_cond.h
@@ -3,8 +3,11 @@
  */
 
 /**
- * @addtogroup ecoli_nodes
+ * @defgroup ecoli_node_cond Condition node
+ * @ingroup ecoli_nodes
  * @{
+ *
+ * @brief A node that conditionally matches based on an expression.
  */
 
 #pragma once

--- a/include/ecoli/node_dynamic.h
+++ b/include/ecoli/node_dynamic.h
@@ -12,12 +12,12 @@
 struct ec_node;
 struct ec_pnode;
 
-/** callback invoked by parse() or complete() to build the dynamic node
- * the behavior of the node can depend on what is already parsed */
+/** Callback invoked by parse() or complete() to build the dynamic node.
+ * The behavior of the node can depend on what is already parsed. */
 typedef struct ec_node *(*ec_node_dynamic_build_t)(struct ec_pnode *pstate, void *opaque);
 
 /**
- * Dynamic node where parsing/validation is done in a user provided callback.
+ * Dynamic node where parsing/validation is done in a user-provided callback.
  */
 struct ec_node *ec_node_dynamic(const char *id, ec_node_dynamic_build_t build, void *opaque);
 

--- a/include/ecoli/node_dynamic.h
+++ b/include/ecoli/node_dynamic.h
@@ -3,8 +3,11 @@
  */
 
 /**
- * @addtogroup ecoli_nodes
+ * @defgroup ecoli_node_dynamic Dynamic node
+ * @ingroup ecoli_nodes
  * @{
+ *
+ * @brief A node built dynamically at parse time by a callback.
  */
 
 #pragma once

--- a/include/ecoli/node_dynlist.h
+++ b/include/ecoli/node_dynlist.h
@@ -21,8 +21,8 @@ struct ec_node;
 struct ec_pnode;
 
 /**
- * Callback invoked by parse() or complete() to build the strvec containing the list of object
- * names.
+ * Callback invoked by parse() or complete() to build the strvec containing the
+ * list of object names.
  *
  * @param pstate
  *   The current parsing state.
@@ -48,7 +48,8 @@ enum ec_node_dynlist_flags {
 	DYNLIST_MATCH_REGEXP = 1 << 1,
 
 	/**
-	 * Don't match names returned by the user callback, even if it matches the regexp.
+	 * Don't match names returned by the user callback, even if it matches
+	 * the regexp.
 	 */
 	DYNLIST_EXCLUDE_LIST = 1 << 2,
 };
@@ -56,9 +57,11 @@ enum ec_node_dynlist_flags {
 /**
  * Create a dynlist node.
  *
- * The parsing and completion depends on a list returned by a user provided callback, a regular
- * expression, and flags.
+ * The parsing and completion depend on a list returned by a user-provided
+ * callback, a regular expression, and flags.
  *
+ * @param id
+ *   The node identifier.
  * @param get
  *   The function that returns the list of object names as a string vector.
  * @param opaque

--- a/include/ecoli/node_dynlist.h
+++ b/include/ecoli/node_dynlist.h
@@ -3,11 +3,14 @@
  */
 
 /**
- * @addtogroup ecoli_nodes
+ * @defgroup ecoli_node_dynlist Dynamic list node
+ * @ingroup ecoli_nodes
  * @{
  *
- * This node is able to parse a list of object names, returned by a user-defined function as
- * a string vector.
+ * @brief A node that matches names from a dynamic list.
+ *
+ * This node is able to parse a list of object names, returned by a user-defined
+ * function as a string vector.
  *
  * Some flags can alter the behavior of parsing and completion:
  * - Match names returned by the user callback.

--- a/include/ecoli/node_empty.h
+++ b/include/ecoli/node_empty.h
@@ -3,8 +3,11 @@
  */
 
 /**
- * @addtogroup ecoli_nodes
+ * @defgroup ecoli_node_empty Empty node
+ * @ingroup ecoli_nodes
  * @{
+ *
+ * @brief A node that matches an empty input.
  */
 
 #pragma once

--- a/include/ecoli/node_expr.h
+++ b/include/ecoli/node_expr.h
@@ -52,6 +52,11 @@ typedef int (*ec_node_expr_eval_pre_op_t)(
 	const struct ec_pnode *operator
 );
 
+/**
+ * Callback function type for evaluating a postfix-operator.
+ *
+ * Same as ec_node_expr_eval_pre_op_t but for postfix operators.
+ */
 typedef int (*ec_node_expr_eval_post_op_t)(
 	void **result,
 	void *userctx,
@@ -59,6 +64,24 @@ typedef int (*ec_node_expr_eval_post_op_t)(
 	const struct ec_pnode *operator
 );
 
+/**
+ * Callback function type for evaluating a binary operator.
+ *
+ * @param result
+ *   On success, this pointer must be set by the user to point
+ *   to a user structure describing the evaluated result.
+ * @param userctx
+ *   A user-defined context passed to all callback functions.
+ * @param operand1
+ *   The evaluated left operand.
+ * @param operator
+ *   The parse result referencing the operator.
+ * @param operand2
+ *   The evaluated right operand.
+ * @return
+ *   0 on success (*result must be set, operands are freed),
+ *   or -errno on error (*result is undefined, operands are not freed).
+ */
 typedef int (*ec_node_expr_eval_bin_op_t)(
 	void **result,
 	void *userctx,
@@ -67,6 +90,24 @@ typedef int (*ec_node_expr_eval_bin_op_t)(
 	void * operand2
 );
 
+/**
+ * Callback function type for evaluating a parenthesized expression.
+ *
+ * @param result
+ *   On success, this pointer must be set by the user to point
+ *   to a user structure describing the evaluated result.
+ * @param userctx
+ *   A user-defined context passed to all callback functions.
+ * @param open_paren
+ *   The parse result referencing the opening parenthesis.
+ * @param close_paren
+ *   The parse result referencing the closing parenthesis.
+ * @param value
+ *   The evaluated expression inside the parentheses.
+ * @return
+ *   0 on success (*result must be set, value is freed),
+ *   or -errno on error (*result is undefined, value is not freed).
+ */
 typedef int (*ec_node_expr_eval_parenthesis_t)(
 	void **result,
 	void *userctx,
@@ -75,28 +116,126 @@ typedef int (*ec_node_expr_eval_parenthesis_t)(
 	void *value
 );
 
+/**
+ * Callback function type for freeing an evaluated result.
+ *
+ * @param result
+ *   The result to free.
+ * @param userctx
+ *   A user-defined context passed to all callback functions.
+ */
 typedef void (*ec_node_expr_eval_free_t)(void *result, void *userctx);
 
+/**
+ * Create an expression node.
+ *
+ * @param id
+ *   The node identifier.
+ * @return
+ *   The node, or NULL on error (errno is set).
+ */
 struct ec_node *ec_node_expr(const char *id);
+
+/**
+ * Set the value (terminal) node for an expression.
+ *
+ * @param gen_node
+ *   The expression node.
+ * @param val_node
+ *   The node matching values. It is consumed and will be freed when the
+ *   parent is freed, or immediately on error.
+ * @return
+ *   0 on success, -1 on error (errno is set).
+ */
 int ec_node_expr_set_val_node(struct ec_node *gen_node, struct ec_node *val_node);
+
+/**
+ * Add a binary operator to an expression node.
+ *
+ * @param gen_node
+ *   The expression node.
+ * @param op
+ *   The operator node. It is consumed and will be freed when the parent
+ *   is freed, or immediately on error.
+ * @return
+ *   0 on success, -1 on error (errno is set).
+ */
 int ec_node_expr_add_bin_op(struct ec_node *gen_node, struct ec_node *op);
+
+/**
+ * Add a prefix operator to an expression node.
+ *
+ * @param gen_node
+ *   The expression node.
+ * @param op
+ *   The operator node. It is consumed and will be freed when the parent
+ *   is freed, or immediately on error.
+ * @return
+ *   0 on success, -1 on error (errno is set).
+ */
 int ec_node_expr_add_pre_op(struct ec_node *gen_node, struct ec_node *op);
+
+/**
+ * Add a postfix operator to an expression node.
+ *
+ * @param gen_node
+ *   The expression node.
+ * @param op
+ *   The operator node. It is consumed and will be freed when the parent
+ *   is freed, or immediately on error.
+ * @return
+ *   0 on success, -1 on error (errno is set).
+ */
 int ec_node_expr_add_post_op(struct ec_node *gen_node, struct ec_node *op);
+
+/**
+ * Add parentheses to an expression node.
+ *
+ * @param gen_node
+ *   The expression node.
+ * @param open
+ *   The opening parenthesis node. It is consumed and will be freed when
+ *   the parent is freed, or immediately on error.
+ * @param close
+ *   The closing parenthesis node. It is consumed and will be freed when
+ *   the parent is freed, or immediately on error.
+ * @return
+ *   0 on success, -1 on error (errno is set).
+ */
 int ec_node_expr_add_parenthesis(
 	struct ec_node *gen_node,
 	struct ec_node *open,
 	struct ec_node *close
 );
 
+/**
+ * Expression evaluation operations.
+ */
 struct ec_node_expr_eval_ops {
-	ec_node_expr_eval_var_t eval_var;
-	ec_node_expr_eval_pre_op_t eval_pre_op;
-	ec_node_expr_eval_post_op_t eval_post_op;
-	ec_node_expr_eval_bin_op_t eval_bin_op;
-	ec_node_expr_eval_parenthesis_t eval_parenthesis;
-	ec_node_expr_eval_free_t eval_free;
+	ec_node_expr_eval_var_t eval_var; /**< Evaluate a variable. */
+	ec_node_expr_eval_pre_op_t eval_pre_op; /**< Evaluate a prefix operator. */
+	ec_node_expr_eval_post_op_t eval_post_op; /**< Evaluate a postfix operator. */
+	ec_node_expr_eval_bin_op_t eval_bin_op; /**< Evaluate a binary operator. */
+	ec_node_expr_eval_parenthesis_t eval_parenthesis; /**< Evaluate parentheses. */
+	ec_node_expr_eval_free_t eval_free; /**< Free an evaluated result. */
 };
 
+/**
+ * Evaluate a parsed expression.
+ *
+ * @param result
+ *   On success, this pointer will be set to the evaluated result.
+ * @param node
+ *   The expression node.
+ * @param parse
+ *   The parse tree to evaluate.
+ * @param ops
+ *   The evaluation callbacks.
+ * @param userctx
+ *   A user-defined context passed to all callbacks.
+ * @return
+ *   0 on success, -1 on error (errno is set).
+ */
 int ec_node_expr_eval(
 	void **result,
 	const struct ec_node *node,

--- a/include/ecoli/node_expr.h
+++ b/include/ecoli/node_expr.h
@@ -3,8 +3,11 @@
  */
 
 /**
- * @addtogroup ecoli_nodes
+ * @defgroup ecoli_node_expr Expression node
+ * @ingroup ecoli_nodes
  * @{
+ *
+ * @brief A node for parsing and evaluating expressions with operators.
  */
 
 #pragma once

--- a/include/ecoli/node_file.h
+++ b/include/ecoli/node_file.h
@@ -3,8 +3,11 @@
  */
 
 /**
- * @addtogroup ecoli_nodes
+ * @defgroup ecoli_node_file File node
+ * @ingroup ecoli_nodes
  * @{
+ *
+ * @brief A node that matches and completes file paths.
  */
 
 #pragma once

--- a/include/ecoli/node_file.h
+++ b/include/ecoli/node_file.h
@@ -24,7 +24,10 @@ struct ec_node_file_ops {
 	int (*fstatat)(int dirfd, const char *pathname, struct stat *buf, int flags);
 };
 
-/** @internal for tests */
+/**
+ * Set custom file operations for testing.
+ * @internal
+ */
 void ec_node_file_set_ops(const struct ec_node_file_ops *ops);
 
 /** @} */

--- a/include/ecoli/node_helper.h
+++ b/include/ecoli/node_helper.h
@@ -19,7 +19,7 @@
 struct ec_node;
 
 /**
- * Build a node table from a node list in a ec_config.
+ * Build a node table from a node list in an ::ec_config.
  *
  * The function takes a node configuration as parameter, which must be a
  * node list. From it, a node table is built. A reference is taken for
@@ -52,7 +52,7 @@ struct ec_node **ec_node_config_node_list_to_table(const struct ec_config *confi
  *   List of pointer to ec_node structures, terminated with
  *   EC_VA_END.
  * @return
- *   A pointer to an ec_config structure. In this case, the
+ *   A pointer to an ::ec_config structure. In this case, the
  *   nodes will be freed when the config structure will be freed.
  *   On error, NULL is returned (and errno is set), and the
  *   nodes are freed.

--- a/include/ecoli/node_int.h
+++ b/include/ecoli/node_int.h
@@ -3,8 +3,11 @@
  */
 
 /**
- * @addtogroup ecoli_nodes
+ * @defgroup ecoli_node_int Integer node
+ * @ingroup ecoli_nodes
  * @{
+ *
+ * @brief Nodes that match signed or unsigned integers.
  */
 
 #pragma once

--- a/include/ecoli/node_int.h
+++ b/include/ecoli/node_int.h
@@ -13,15 +13,64 @@
 
 #include <ecoli/node.h>
 
-/* ec_node("int", ...) can be used too
- * default is no limit, base 10 */
-
+/**
+ * Create a signed integer node.
+ *
+ * @param id
+ *   The node identifier.
+ * @param min
+ *   The minimum valid value (included).
+ * @param max
+ *   The maximum valid value (included).
+ * @param base
+ *   The base to use for parsing. If 0, try to guess from prefix.
+ * @return
+ *   The node, or NULL on error (errno is set).
+ */
 struct ec_node *ec_node_int(const char *id, int64_t min, int64_t max, unsigned int base);
 
+/**
+ * Get the value of a parsed signed integer.
+ *
+ * @param node
+ *   The integer node.
+ * @param str
+ *   The string to parse.
+ * @param result
+ *   Pointer where the result will be stored on success.
+ * @return
+ *   0 on success, -1 on error (errno is set).
+ */
 int ec_node_int_getval(const struct ec_node *node, const char *str, int64_t *result);
 
+/**
+ * Create an unsigned integer node.
+ *
+ * @param id
+ *   The node identifier.
+ * @param min
+ *   The minimum valid value (included).
+ * @param max
+ *   The maximum valid value (included).
+ * @param base
+ *   The base to use for parsing. If 0, try to guess from prefix.
+ * @return
+ *   The node, or NULL on error (errno is set).
+ */
 struct ec_node *ec_node_uint(const char *id, uint64_t min, uint64_t max, unsigned int base);
 
+/**
+ * Get the value of a parsed unsigned integer.
+ *
+ * @param node
+ *   The unsigned integer node.
+ * @param str
+ *   The string to parse.
+ * @param result
+ *   Pointer where the result will be stored on success.
+ * @return
+ *   0 on success, -1 on error (errno is set).
+ */
 int ec_node_uint_getval(const struct ec_node *node, const char *str, uint64_t *result);
 
 /** @} */

--- a/include/ecoli/node_many.h
+++ b/include/ecoli/node_many.h
@@ -3,8 +3,11 @@
  */
 
 /**
- * @addtogroup ecoli_nodes
+ * @defgroup ecoli_node_many Many node
+ * @ingroup ecoli_nodes
  * @{
+ *
+ * @brief A node that matches its child multiple times.
  */
 
 #pragma once

--- a/include/ecoli/node_many.h
+++ b/include/ecoli/node_many.h
@@ -9,12 +9,39 @@
 
 #pragma once
 
-/*
- * if min == max == 0, there is no limit
+/**
+ * Create a many node that matches its child multiple times.
+ *
+ * @param id
+ *   The node identifier.
+ * @param child
+ *   The child node. It is consumed and will be freed when the parent
+ *   is freed, or immediately on error.
+ * @param min
+ *   Minimum number of repetitions. Use 0 for no minimum.
+ * @param max
+ *   Maximum number of repetitions. Use 0 for no maximum.
+ * @return
+ *   The node, or NULL on error (errno is set).
  */
 struct ec_node *
 ec_node_many(const char *id, struct ec_node *child, unsigned int min, unsigned int max);
 
+/**
+ * Set the parameters of a many node.
+ *
+ * @param gen_node
+ *   The many node.
+ * @param child
+ *   The child node. It is consumed and will be freed when the parent
+ *   is freed, or immediately on error.
+ * @param min
+ *   Minimum number of repetitions. Use 0 for no minimum.
+ * @param max
+ *   Maximum number of repetitions. Use 0 for no maximum.
+ * @return
+ *   0 on success, -1 on error (errno is set).
+ */
 int ec_node_many_set_params(
 	struct ec_node *gen_node,
 	struct ec_node *child,

--- a/include/ecoli/node_none.h
+++ b/include/ecoli/node_none.h
@@ -3,8 +3,11 @@
  */
 
 /**
- * @addtogroup ecoli_nodes
+ * @defgroup ecoli_node_none None node
+ * @ingroup ecoli_nodes
  * @{
+ *
+ * @brief A node that never matches anything.
  */
 
 #pragma once

--- a/include/ecoli/node_once.h
+++ b/include/ecoli/node_once.h
@@ -12,25 +12,25 @@
 #include <ecoli/node.h>
 
 /**
- * This node behaves like its child, but prevent from parsing it several times.
+ * This node behaves like its child, but prevents it from being parsed more than once.
  *
  * Example:
  *
- * ```
+ * @code{.c}
  *   many(
  *     or(
  *       once(str("foo")),
  *       str("bar")))
- * ```
+ * @endcode
  *
- * Matches: [], ["foo", "bar"], ["bar", "bar"], ["foo", "bar", "bar"], ...
- * But not: ["foo", "foo"], ["foo", "bar", "foo"], ...
+ * Matches: `[]`, `["foo", "bar"]`, `["bar", "bar"]`, `["foo", "bar", "bar"]`, ...
+ * But not: `["foo", "foo"]`, `["foo", "bar", "foo"]`, ...
  *
- * on error, child is *not* freed
+ * On error, the child is not freed.
  */
 struct ec_node *ec_node_once(const char *id, struct ec_node *child);
 
-/** on error, child is freed */
+/** Set the child of a once node. On error, the child is freed. */
 int ec_node_once_set_child(struct ec_node *node, struct ec_node *child);
 
 /** @} */

--- a/include/ecoli/node_once.h
+++ b/include/ecoli/node_once.h
@@ -3,8 +3,11 @@
  */
 
 /**
- * @addtogroup ecoli_nodes
+ * @defgroup ecoli_node_once Once node
+ * @ingroup ecoli_nodes
  * @{
+ *
+ * @brief A node that prevents its child from being parsed more than once.
  */
 
 #pragma once

--- a/include/ecoli/node_option.h
+++ b/include/ecoli/node_option.h
@@ -3,8 +3,11 @@
  */
 
 /**
- * @addtogroup ecoli_nodes
+ * @defgroup ecoli_node_option Option node
+ * @ingroup ecoli_nodes
  * @{
+ *
+ * @brief A node that makes its child optional.
  */
 
 #pragma once

--- a/include/ecoli/node_option.h
+++ b/include/ecoli/node_option.h
@@ -11,7 +11,30 @@
 
 #include <ecoli/node.h>
 
+/**
+ * Create an option node that makes its child optional.
+ *
+ * @param id
+ *   The node identifier.
+ * @param node
+ *   The child node. It is consumed and will be freed when the parent
+ *   is freed, or immediately on error.
+ * @return
+ *   The node, or NULL on error (errno is set).
+ */
 struct ec_node *ec_node_option(const char *id, struct ec_node *node);
+
+/**
+ * Set the child of an option node.
+ *
+ * @param gen_node
+ *   The option node.
+ * @param child
+ *   The child node. It is consumed and will be freed when the parent
+ *   is freed, or immediately on error.
+ * @return
+ *   0 on success, -1 on error (errno is set).
+ */
 int ec_node_option_set_child(struct ec_node *gen_node, struct ec_node *child);
 
 /** @} */

--- a/include/ecoli/node_or.h
+++ b/include/ecoli/node_or.h
@@ -3,8 +3,11 @@
  */
 
 /**
- * @addtogroup ecoli_nodes
+ * @defgroup ecoli_node_or Or node
+ * @ingroup ecoli_nodes
  * @{
+ *
+ * @brief A node that matches one of its child nodes.
  */
 
 #pragma once

--- a/include/ecoli/node_or.h
+++ b/include/ecoli/node_or.h
@@ -14,7 +14,8 @@
 
 /**
  * Create a new "or" node from an arbitrary list of child nodes.
- * All nodes given in the list will be freed when freeing this one.
+ * All nodes given in the list will be freed when freeing this one,
+ * or immediately on error.
  */
 #define EC_NODE_OR(args...) __ec_node_or(args, EC_VA_END)
 
@@ -30,7 +31,10 @@ struct ec_node *__ec_node_or(const char *id, ...);
 struct ec_node *ec_node_or(const char *id);
 
 /**
- * Add a child to an "or" node. Child is consumed.
+ * Add a child to an "or" node.
+ *
+ * The child is consumed and will be freed when the parent is freed,
+ * or immediately on error.
  */
 int ec_node_or_add(struct ec_node *node, struct ec_node *child);
 

--- a/include/ecoli/node_re.h
+++ b/include/ecoli/node_re.h
@@ -11,9 +11,28 @@
 
 #include <ecoli/node.h>
 
+/**
+ * Create a regular expression node.
+ *
+ * @param id
+ *   The node identifier.
+ * @param str
+ *   The regular expression pattern (POSIX extended regex).
+ * @return
+ *   The node, or NULL on error (errno is set).
+ */
 struct ec_node *ec_node_re(const char *id, const char *str);
 
-/* re is duplicated */
+/**
+ * Set the regular expression on a regex node.
+ *
+ * @param node
+ *   The regex node.
+ * @param re
+ *   The regular expression pattern. It is duplicated internally.
+ * @return
+ *   0 on success, -1 on error (errno is set).
+ */
 int ec_node_re_set_regexp(struct ec_node *node, const char *re);
 
 /** @} */

--- a/include/ecoli/node_re.h
+++ b/include/ecoli/node_re.h
@@ -3,8 +3,11 @@
  */
 
 /**
- * @addtogroup ecoli_nodes
+ * @defgroup ecoli_node_re Regex node
+ * @ingroup ecoli_nodes
  * @{
+ *
+ * @brief A node that matches input against a regular expression.
  */
 
 #pragma once

--- a/include/ecoli/node_re_lex.h
+++ b/include/ecoli/node_re_lex.h
@@ -11,8 +11,36 @@
 
 #include <ecoli/node.h>
 
+/**
+ * Create a regex-based lexer node.
+ *
+ * This node tokenizes the input using regular expressions added with
+ * ec_node_re_lex_add() and passes the resulting tokens to the child node.
+ *
+ * @param id
+ *   The node identifier.
+ * @param child
+ *   The child node. It is consumed and will be freed when the parent
+ *   is freed, or immediately on error.
+ * @return
+ *   The node, or NULL on error (errno is set).
+ */
 struct ec_node *ec_node_re_lex(const char *id, struct ec_node *child);
 
+/**
+ * Add a token pattern to a regex lexer node.
+ *
+ * @param gen_node
+ *   The regex lexer node.
+ * @param pattern
+ *   The regular expression pattern for matching tokens.
+ * @param keep
+ *   If non-zero, include matched tokens in the output; if zero, discard them.
+ * @param attr_name
+ *   Optional attribute name to attach to matched tokens, or NULL.
+ * @return
+ *   0 on success, -1 on error (errno is set).
+ */
 int ec_node_re_lex_add(
 	struct ec_node *gen_node,
 	const char *pattern,

--- a/include/ecoli/node_re_lex.h
+++ b/include/ecoli/node_re_lex.h
@@ -3,8 +3,11 @@
  */
 
 /**
- * @addtogroup ecoli_nodes
+ * @defgroup ecoli_node_re_lex Regex lexer node
+ * @ingroup ecoli_nodes
  * @{
+ *
+ * @brief A lexer node using regular expressions for tokenization.
  */
 
 #pragma once

--- a/include/ecoli/node_seq.h
+++ b/include/ecoli/node_seq.h
@@ -11,6 +11,18 @@
 
 #include <ecoli/node.h>
 
+/**
+ * Create a sequence node from a list of child nodes.
+ *
+ * All child nodes passed as arguments are consumed and will be freed
+ * when the sequence node is freed, or immediately on error.
+ *
+ * Example:
+ *
+ * @code{.c}
+ * EC_NODE_SEQ("myseq", child1, child2, child3)
+ * @endcode
+ */
 #define EC_NODE_SEQ(args...) __ec_node_seq(args, EC_VA_END)
 
 /* list must be terminated with EC_VA_END */
@@ -19,9 +31,29 @@
  * ec_node_seq() + ec_node_seq_add() */
 struct ec_node *__ec_node_seq(const char *id, ...);
 
+/**
+ * Create an empty sequence node.
+ *
+ * Use ec_node_seq_add() to add children.
+ *
+ * @param id
+ *   The node identifier.
+ * @return
+ *   The node, or NULL on error (errno is set).
+ */
 struct ec_node *ec_node_seq(const char *id);
 
-/* child is consumed */
+/**
+ * Add a child to a sequence node.
+ *
+ * @param node
+ *   The sequence node.
+ * @param child
+ *   The child node to add. It is consumed and will be freed when the
+ *   parent is freed, or immediately on error.
+ * @return
+ *   0 on success, -1 on error (errno is set).
+ */
 int ec_node_seq_add(struct ec_node *node, struct ec_node *child);
 
 /** @} */

--- a/include/ecoli/node_seq.h
+++ b/include/ecoli/node_seq.h
@@ -3,8 +3,11 @@
  */
 
 /**
- * @addtogroup ecoli_nodes
+ * @defgroup ecoli_node_seq Sequence node
+ * @ingroup ecoli_nodes
  * @{
+ *
+ * @brief A node that matches a sequence of child nodes in order.
  */
 
 #pragma once

--- a/include/ecoli/node_sh_lex.h
+++ b/include/ecoli/node_sh_lex.h
@@ -11,8 +11,35 @@
 
 #include <ecoli/node.h>
 
+/**
+ * Create a shell lexer node.
+ *
+ * This node tokenizes the input using shell-like lexing rules (handling
+ * quotes, escapes, etc.) and passes the resulting tokens to the child node.
+ *
+ * @param id
+ *   The node identifier.
+ * @param child
+ *   The child node. It is consumed and will be freed when the parent
+ *   is freed, or immediately on error.
+ * @return
+ *   The node, or NULL on error (errno is set).
+ */
 struct ec_node *ec_node_sh_lex(const char *id, struct ec_node *child);
 
+/**
+ * Create a shell lexer node with variable expansion.
+ *
+ * Same as ec_node_sh_lex() but with shell variable expansion enabled.
+ *
+ * @param id
+ *   The node identifier.
+ * @param child
+ *   The child node. It is consumed and will be freed when the parent
+ *   is freed, or immediately on error.
+ * @return
+ *   The node, or NULL on error (errno is set).
+ */
 struct ec_node *ec_node_sh_lex_expand(const char *id, struct ec_node *child);
 
 /** @} */

--- a/include/ecoli/node_sh_lex.h
+++ b/include/ecoli/node_sh_lex.h
@@ -3,8 +3,11 @@
  */
 
 /**
- * @addtogroup ecoli_nodes
+ * @defgroup ecoli_node_sh_lex Shell lexer node
+ * @ingroup ecoli_nodes
  * @{
+ *
+ * @brief A lexer node using shell-like tokenization rules.
  */
 
 #pragma once

--- a/include/ecoli/node_space.h
+++ b/include/ecoli/node_space.h
@@ -3,8 +3,11 @@
  */
 
 /**
- * @addtogroup ecoli_nodes
+ * @defgroup ecoli_node_space Space node
+ * @ingroup ecoli_nodes
  * @{
+ *
+ * @brief A node that matches whitespace.
  *
  * This node matches one string in the vector if it is only composed of
  * spaces, as interpreted by isspace().

--- a/include/ecoli/node_str.h
+++ b/include/ecoli/node_str.h
@@ -11,9 +11,28 @@
 
 #include <ecoli/node.h>
 
+/**
+ * Create a string node that matches a specific string.
+ *
+ * @param id
+ *   The node identifier.
+ * @param str
+ *   The string to match.
+ * @return
+ *   The node, or NULL on error (errno is set).
+ */
 struct ec_node *ec_node_str(const char *id, const char *str);
 
-/* str is duplicated */
+/**
+ * Set the string to match on a string node.
+ *
+ * @param node
+ *   The string node.
+ * @param str
+ *   The string to match. It is duplicated internally.
+ * @return
+ *   0 on success, -1 on error (errno is set).
+ */
 int ec_node_str_set_str(struct ec_node *node, const char *str);
 
 /** @} */

--- a/include/ecoli/node_str.h
+++ b/include/ecoli/node_str.h
@@ -3,8 +3,11 @@
  */
 
 /**
- * @addtogroup ecoli_nodes
+ * @defgroup ecoli_node_str String node
+ * @ingroup ecoli_nodes
  * @{
+ *
+ * @brief A node that matches a specific string.
  */
 
 #pragma once

--- a/include/ecoli/node_subset.h
+++ b/include/ecoli/node_subset.h
@@ -3,8 +3,11 @@
  */
 
 /**
- * @addtogroup ecoli_nodes
+ * @defgroup ecoli_node_subset Subset node
+ * @ingroup ecoli_nodes
  * @{
+ *
+ * @brief A node that matches any subset of its children in any order.
  */
 
 #pragma once

--- a/include/ecoli/node_subset.h
+++ b/include/ecoli/node_subset.h
@@ -11,6 +11,19 @@
 
 #include <ecoli/node.h>
 
+/**
+ * Create a subset node from a list of child nodes.
+ *
+ * A subset node matches any permutation of a subset of its children.
+ * All child nodes passed as arguments are consumed and will be freed
+ * when the subset node is freed, or immediately on error.
+ *
+ * Example:
+ *
+ * @code{.c}
+ * EC_NODE_SUBSET("mysubset", child1, child2, child3)
+ * @endcode
+ */
 #define EC_NODE_SUBSET(args...) __ec_node_subset(args, EC_VA_END)
 
 /* list must be terminated with EC_VA_END */
@@ -19,9 +32,29 @@
  * ec_node_subset() + ec_node_subset_add() */
 struct ec_node *__ec_node_subset(const char *id, ...);
 
+/**
+ * Create an empty subset node.
+ *
+ * Use ec_node_subset_add() to add children.
+ *
+ * @param id
+ *   The node identifier.
+ * @return
+ *   The node, or NULL on error (errno is set).
+ */
 struct ec_node *ec_node_subset(const char *id);
 
-/* child is consumed */
+/**
+ * Add a child to a subset node.
+ *
+ * @param node
+ *   The subset node.
+ * @param child
+ *   The child node to add. It is consumed and will be freed when the
+ *   parent is freed, or immediately on error.
+ * @return
+ *   0 on success, -1 on error (errno is set).
+ */
 int ec_node_subset_add(struct ec_node *node, struct ec_node *child);
 
 /** @} */

--- a/include/ecoli/parse.h
+++ b/include/ecoli/parse.h
@@ -397,7 +397,18 @@ unsigned int ec_pnode_count(const struct ec_pnode *root, const char *id);
 struct ec_pnode *
 __ec_pnode_iter_next(const struct ec_pnode *root, struct ec_pnode *pnode, bool iter_children);
 
-/* keep the const if any */
+/**
+ * Get the next node in a parse tree iteration.
+ *
+ * @param root
+ *   The root of the parse tree being iterated.
+ * @param parse
+ *   The current parse node.
+ * @param iter_children
+ *   If true, iterate over children; if false, skip to siblings.
+ * @return
+ *   The next parse node, or NULL if iteration is complete.
+ */
 #define EC_PNODE_ITER_NEXT(root, parse, iter_children)                                             \
 	({                                                                                         \
 		const struct ec_pnode *p_ = parse; /* check type */                                \
@@ -420,13 +431,24 @@ __ec_pnode_iter_next(const struct ec_pnode *root, struct ec_pnode *pnode, bool i
 	for ((iter) = (root); (iter) != NULL; (iter) = EC_PNODE_ITER_NEXT((root), (iter), true))
 
 /**
- * Get the total number of elements in a parse node.
+ * Get the number of strings in the parsed string vector.
+ *
+ * @param pnode
+ *   A node in the parsing tree.
+ * @return
+ *   The number of strings in the parsed string vector, or 0 if the
+ *   node is NULL or has no string vector.
  */
 size_t ec_pnode_len(const struct ec_pnode *pnode);
 
 /**
- * Get the number of matches.
+ * Check if the parsing tree matches the input.
+ *
+ * @param pnode
+ *   A node in the parsing tree.
+ * @return
+ *   true if the parsing tree matches (has a string vector), false otherwise.
  */
-size_t ec_pnode_matches(const struct ec_pnode *pnode);
+bool ec_pnode_matches(const struct ec_pnode *pnode);
 
 /** @} */

--- a/include/ecoli/parse.h
+++ b/include/ecoli/parse.h
@@ -15,7 +15,7 @@
  * tree that describes which part of the input matches which node.
  *
  * The parsing tree is sometimes referenced by another node than the
- * root node. Use ec_pnode_get_root() to get the root node in that case.
+ * root node. Use ::ec_pnode_get_root() to get the root node in that case.
  */
 
 #pragma once
@@ -73,24 +73,24 @@ void ec_pnode_free_children(struct ec_pnode *pnode);
 struct ec_pnode *ec_pnode_dup(const struct ec_pnode *pnode);
 
 /**
- * Get the string vector associated to a parsing node.
+ * Get the string vector associated with a parsing node.
  *
- * When an input is parsed successfully (i.e. the input string vector
+ * When an input is parsed successfully (i.e., the input string vector
  * matches the grammar tree), the matching string vector is copied
  * inside the associated parsing node.
  *
- * For instance, parsing the input ["foo", "bar"] on a grammar which is
- * a sequence of strings, the attached string vector will be ["foo",
- * "bar"] on the root pnode, ["foo"] on the first leaf, and ["bar"] on
+ * For instance, parsing the input `["foo", "bar"]` on a grammar which is
+ * a sequence of strings, the attached string vector will be `["foo",
+ * "bar"]` on the root pnode, `["foo"]` on the first leaf, and `["bar"]` on
  * the second leaf.
  *
- * If the parsing tree does not match (see ec_pnode_matches()), it
+ * If the parsing tree does not match (see ec_pnode_matches()),
  * the associated string vector is NULL.
  *
  * @param pnode
  *   The parsing node. If NULL, the function returns NULL.
  * @return
- *   The string vector associated to the parsing node, or NULL
+ *   The string vector associated with the parsing node, or NULL
  *   if the node is not yet parsed (this happens when building the
  *   parsing tree), or if the parsing tree does not match the
  *   input.
@@ -118,8 +118,8 @@ struct ec_pnode *ec_parse(const struct ec_node *node, const char *str);
  * Generate a parsing tree by parsing the input string vector using the
  * given grammar tree.
  *
- * The parsing tree is composed of struct ec_pnode, and each of them is
- * associated to a struct ec_node (the grammar node), to the string vector
+ * The parsing tree is composed of ::ec_pnode, and each of them is
+ * associated with a ::ec_node (the grammar node), to the string vector
  * that matched the subtree, and to optional attributes.
  *
  * When the input matches the grammar tree, the string vector associated
@@ -148,7 +148,7 @@ struct ec_pnode *ec_parse_strvec(const struct ec_node *node, const struct ec_str
  * Parse a string vector using a grammar tree, from a parent node.
  *
  * This function is usually called from an intermediate node (like
- * ec_node_seq, ec_node_or, ...) to backfill the parsing tree, which is
+ * ec_node_seq(), ec_node_or(), ...) to backfill the parsing tree, which is
  * built piece by piece while browsing the grammar tree.
  *
  * ec_parse_child() creates a new child in this parsing tree, and calls
@@ -164,7 +164,7 @@ struct ec_pnode *ec_parse_strvec(const struct ec_node *node, const struct ec_str
  *   The input string vector.
  * @return
  *   On success: the number of matched elements in the input string
- *   vector (which can be 0), or EC_PARSE_NOMATCH (which is a positive
+ *   vector (which can be 0), or ::EC_PARSE_NOMATCH (which is a positive
  *   value) if the input does not match the grammar. On error, -1 is
  *   returned, and errno is set.
  */
@@ -265,11 +265,11 @@ struct ec_pnode *ec_pnode_get_last_child(const struct ec_pnode *pnode);
 /**
  * Get the next sibling node.
  *
- * If pnode is the root of the parsing tree, return NULL. Else return
+ * If pnode is the root of the parsing tree, return NULL. Otherwise, return
  * the next sibling node.
  *
  * @param pnode
- *   A node in the parsing tree..
+ *   A node in the parsing tree.
  * @return
  *   The next sibling, or NULL if there is no sibling.
  */
@@ -300,9 +300,9 @@ const struct ec_node *ec_pnode_get_node(const struct ec_pnode *pnode);
  * Unlink and free the last child.
  *
  * Shortcut to unlink and free the last child of a node. It is a quite
- * common operation in intermediate nodes (like ec_node_seq,
- * ec_node_many, ...) to remove a subtree that was temporarily added
- * when during the completion process.
+ * common operation in intermediate nodes (like ec_node_seq(),
+ * ec_node_many(), ...) to remove a subtree that was temporarily added
+ * during the completion process.
  *
  * @param pnode
  *   A node in the parsing tree which has at least one child.
@@ -310,7 +310,7 @@ const struct ec_node *ec_pnode_get_node(const struct ec_pnode *pnode);
 void ec_pnode_del_last_child(struct ec_pnode *pnode);
 
 /**
- * Get attributes associated to a node in a parsing tree.
+ * Get attributes associated with a node in a parsing tree.
  *
  * Attributes are key/values that are stored in a dictionary
  * and attached to a node in the parsing tree. An attribute can be
@@ -389,10 +389,13 @@ const struct ec_pnode *ec_pnode_find_next(
 unsigned int ec_pnode_count(const struct ec_pnode *root, const char *id);
 
 /**
- * Iterate among parse tree
+ * Iterate over a parse tree
  *
  * Use it with:
+ *
+ * @code{.c}
  * for (iter = pnode; iter != NULL; iter = EC_PNODE_ITER_NEXT(pnode, iter, 1))
+ * @endcode
  */
 struct ec_pnode *
 __ec_pnode_iter_next(const struct ec_pnode *root, struct ec_pnode *pnode, bool iter_children);

--- a/include/ecoli/string.h
+++ b/include/ecoli/string.h
@@ -16,13 +16,13 @@
 #include <stddef.h>
 #include <stdint.h>
 
-/** count the number of identical chars at the beginning of 2 strings */
+/** Count the number of identical characters at the beginning of two strings. */
 size_t ec_strcmp_count(const char *s1, const char *s2);
 
-/** return 1 if 's' starts with 'beginning' */
+/** Return 1 if the string starts with the given prefix. */
 int ec_str_startswith(const char *s, const char *beginning);
 
-/** return true if string is only composed of spaces (' ', '\n', ...) */
+/** Return true if the string contains only whitespace characters. */
 bool ec_str_is_space(const char *s);
 
 /**
@@ -39,7 +39,7 @@ bool ec_str_is_space(const char *s);
  * @param val
  *   The pointer to the value to be set on success.
  * @return
- *   On success, return 0. Else, return -1 and set errno.
+ *   On success, return 0. Otherwise, return -1 and set errno.
  */
 int ec_str_parse_llint(const char *str, unsigned int base, int64_t min, int64_t max, int64_t *val);
 
@@ -57,7 +57,7 @@ int ec_str_parse_llint(const char *str, unsigned int base, int64_t min, int64_t 
  * @param val
  *   The pointer to the value to be set on success.
  * @return
- *   On success, return 0. Else, return -1 and set errno.
+ *   On success, return 0. Otherwise, return -1 and set errno.
  */
 int ec_str_parse_ullint(
 	const char *str,
@@ -76,7 +76,8 @@ int ec_str_parse_ullint(
  *   The quote character to use: usually " or ' but can be anything. If 0,
  *   select between " or ' automatically.
  * @param force
- *   If true, always add quotes, else add them only if the string contains spaces or quotes.
+ *   If true, always add quotes, else add them only if the string contains
+ *   spaces or quotes.
  * @return
  *   An allocated string, that must be freed by the caller using free().
  */
@@ -90,9 +91,11 @@ char *ec_str_quote(const char *str, char quote, bool force);
  * @param max_cols
  *   The maximum number of columns.
  * @param start_off
- *   The number of already consumed columns on the first line, filled with padding in other lines.
+ *   The number of already consumed columns on the first line, filled with
+ *   padding in other lines.
  * @return
- *   An allocated string containing the wrapped text. It must be freed by the user using free().
+ *   An allocated string containing the wrapped text. It must be freed by the
+ *   user using free().
  */
 char *ec_str_wrap(const char *str, size_t max_cols, size_t start_off);
 

--- a/include/ecoli/strvec.h
+++ b/include/ecoli/strvec.h
@@ -8,7 +8,7 @@
  *
  * @brief Helpers for strings vectors manipulation.
  *
- * The ec_strvec API provide helpers to manipulate string vectors.
+ * The ::ec_strvec API provides helpers to manipulate string vectors.
  * When duplicating vectors, the strings are not duplicated in memory,
  * a reference counter is used.
  */
@@ -28,7 +28,7 @@ struct ec_strvec;
 struct ec_strvec *ec_strvec(void);
 
 /**
- * Allocate a new string vector
+ * Allocate a new string vector.
  *
  * The string vector is initialized with the list of const strings
  * passed as arguments.
@@ -42,7 +42,7 @@ struct ec_strvec *ec_strvec(void);
 		ec_strvec_from_array(_arr, EC_COUNT_OF(_arr));                                     \
 	})
 /**
- * Allocate a new string vector
+ * Allocate a new string vector.
  *
  * The string vector is initialized with the array of const strings
  * passed as arguments.
@@ -222,7 +222,7 @@ const struct ec_dict *ec_strvec_get_attrs(const struct ec_strvec *strvec, size_t
 int ec_strvec_set_attrs(struct ec_strvec *strvec, size_t idx, struct ec_dict *attrs);
 
 /**
- * Compare two string vectors
+ * Compare two string vectors.
  *
  * @param strvec1
  *   The pointer to the first string vector.

--- a/include/ecoli/vec.h
+++ b/include/ecoli/vec.h
@@ -8,7 +8,7 @@
  *
  * @brief Helpers for vectors manipulation.
  *
- * The ec_vec API provide helpers to manipulate vectors of objects
+ * The ::ec_vec API provides helpers to manipulate vectors of objects
  * of any kind.
  */
 
@@ -20,14 +20,14 @@
 /**
  * Custom free callback.
  *
- * If NULL, default does nothing
+ * If NULL, the default does nothing.
  */
 typedef void (*ec_vec_elt_free_t)(void *ptr);
 
 /**
- * Custom copy callback
+ * Custom copy callback.
  *
- * If NULL, default is: `memcpy(dst, src, vec->elt_size)`
+ * If NULL, the default is: `memcpy(dst, src, vec->elt_size)`.
  */
 typedef void (*ec_vec_elt_copy_t)(void *dst, void *src);
 
@@ -59,7 +59,7 @@ struct ec_vec *ec_vec_ndup(const struct ec_vec *vec, size_t off, size_t len);
 /** Free a vector and all its contents. */
 void ec_vec_free(struct ec_vec *vec);
 
-/** Get the size of a vector. */
+/** Get the number of elements in a vector. */
 __attribute__((pure)) size_t ec_vec_len(const struct ec_vec *vec);
 
 /** @} */

--- a/include/ecoli/yaml.h
+++ b/include/ecoli/yaml.h
@@ -16,7 +16,7 @@
 struct ec_node;
 
 /**
- * Parse a YAML file and build an ec_node tree from it.
+ * Parse a YAML file and build an ::ec_node tree from it.
  *
  * @param filename
  *   The path to the file to be parsed.
@@ -27,9 +27,9 @@ struct ec_node;
 struct ec_node *ec_yaml_import(const char *filename);
 
 /**
- * Export an ec_node tree to a YAML formatted stream.
+ * Export an ::ec_node tree to a YAML formatted stream.
  *
- * This function traverses the ec_node tree and outputs a YAML representation
+ * This function traverses the ::ec_node tree and outputs a YAML representation
  * of the grammar structure including node type, id, help, attributes and
  * configuration. The output can be used as a template or documentation
  * for grammar definitions.

--- a/include/meson.build
+++ b/include/meson.build
@@ -43,5 +43,6 @@ libecoli_headers = files(
 	'ecoli/vec.h',
 	'ecoli/yaml.h',
 )
+doc_sources += libecoli_headers
 
 install_headers(libecoli_headers, preserve_path: true)

--- a/meson.build
+++ b/meson.build
@@ -19,6 +19,7 @@ add_project_arguments('-D_GNU_SOURCE', language : 'c')
 
 inc = include_directories('include')
 libecoli_sources = []
+doc_sources = []
 
 subdir('src')
 subdir('include')

--- a/src/editline.c
+++ b/src/editline.c
@@ -22,7 +22,7 @@
 #include <ecoli/utils.h>
 
 struct ec_editline {
-	EditLine *el;
+	struct editline *el;
 	History *history;
 	char *hist_file;
 	HistEvent histev;
@@ -49,7 +49,7 @@ int ec_editline_term_size(
 	return 0;
 }
 
-static char *prompt_cb(EditLine *el)
+static char *prompt_cb(struct editline *el)
 {
 	struct ec_editline *editline;
 	void *clientdata;
@@ -119,7 +119,7 @@ struct ec_editline *ec_editline(
 )
 {
 	struct ec_editline *editline = NULL;
-	EditLine *el;
+	struct editline *el;
 
 	if (f_in == NULL || f_out == NULL || f_err == NULL) {
 		errno = EINVAL;
@@ -204,7 +204,7 @@ void ec_editline_free(struct ec_editline *editline)
 	free(editline);
 }
 
-EditLine *ec_editline_get_el(struct ec_editline *editline)
+struct editline *ec_editline_get_el(struct ec_editline *editline)
 {
 	return editline->el;
 }
@@ -227,7 +227,7 @@ int ec_editline_set_node(struct ec_editline *editline, const struct ec_node *nod
 
 int ec_editline_set_history(struct ec_editline *editline, size_t hist_size, const char *hist_file)
 {
-	EditLine *el = editline->el;
+	struct editline *el = editline->el;
 
 	if (editline->history != NULL)
 		history_end(editline->history);
@@ -294,7 +294,7 @@ fail:
 	return NULL;
 }
 
-int ec_editline_complete(EditLine *el, int c)
+int ec_editline_complete(struct editline *el, int c)
 {
 	struct ec_editline *editline;
 	int ret = CC_REFRESH;
@@ -432,7 +432,7 @@ fail:
 
 char *ec_editline_gets(struct ec_editline *editline)
 {
-	EditLine *el = editline->el;
+	struct editline *el = editline->el;
 	char *line_copy = NULL;
 	const char *line;
 	int count;

--- a/src/parse.c
+++ b/src/parse.c
@@ -462,13 +462,13 @@ size_t ec_pnode_len(const struct ec_pnode *pnode)
 	return ec_strvec_len(pnode->strvec);
 }
 
-size_t ec_pnode_matches(const struct ec_pnode *pnode)
+bool ec_pnode_matches(const struct ec_pnode *pnode)
 {
 	if (pnode == NULL)
-		return 0;
+		return false;
 
 	if (pnode->strvec == NULL)
-		return 0;
+		return false;
 
-	return 1;
+	return true;
 }


### PR DESCRIPTION
This series improves the doxygen-generated documentation for libecoli.

The main page has been rewritten with a comprehensive overview covering key features, core concepts, a complete working example, and categorized tables of all available node types. The architecture document has been converted from markdown to doxygen format with proper cross-references and diagram integration.

Each node type header now defines its own documentation subgroup instead of being lumped into a flat list, making the API reference easier to navigate. A build-time helper generates configuration schema documentation for each node type automatically.

The example programs are now included in the generated documentation with descriptions explaining what each one demonstrates. Various docstring issues have been fixed including missing documentation for public structs, incorrect cross-reference syntax, and formatting inconsistencies.

The CI documentation build has been moved to a Fedora container to match the development environment.

Here is a preview of the result: https://f.jarry.cc/ecoli-doc-demo