### PR TITLE
fix various buffer overflows, memory leaks and logic bugs

### DIFF
--- a/include/ecoli/dict.h
+++ b/include/ecoli/dict.h
@@ -40,10 +40,11 @@ struct ec_dict *ec_dict(void);
  * @param dict
  *   The hash table.
  * @param key
- *   The key string.
+ *   The key string. Must not be NULL.
  * @return
  *   The element if it is found, or NULL on error (errno is set).
  *   In case of success but the element is NULL, errno is set to 0.
+ *   If key is NULL, errno is set to EINVAL.
  */
 void *ec_dict_get(const struct ec_dict *dict, const char *key);
 
@@ -53,9 +54,10 @@ void *ec_dict_get(const struct ec_dict *dict, const char *key);
  * @param dict
  *   The hash table.
  * @param key
- *   The key string.
+ *   The key string. Must not be NULL.
  * @return
- *   true if it contains the key, else false.
+ *   true if it contains the key, false otherwise.
+ *   If key is NULL, false is returned and errno is set to EINVAL.
  */
 bool ec_dict_has_key(const struct ec_dict *dict, const char *key);
 
@@ -65,7 +67,7 @@ bool ec_dict_has_key(const struct ec_dict *dict, const char *key);
  * @param dict
  *   The hash table.
  * @param key
- *   The key string.
+ *   The key string. Must not be NULL.
  * @return
  *   0 on success, or -1 on error (errno is set).
  */
@@ -77,7 +79,7 @@ int ec_dict_del(struct ec_dict *dict, const char *key);
  * @param dict
  *   The hash table.
  * @param key
- *   The key string.
+ *   The key string. Must not be NULL.
  * @param val
  *   The pointer to be saved in the hash table.
  * @param free_cb

--- a/src/config.c
+++ b/src/config.c
@@ -844,10 +844,10 @@ __ec_config_dump(FILE *out, const char *key, const struct ec_config *value, size
 			ret = asprintf(&val_str, "false");
 		break;
 	case EC_CONFIG_TYPE_INT64:
-		ret = asprintf(&val_str, "%" PRIu64, value->u64);
+		ret = asprintf(&val_str, "%" PRIi64, value->i64);
 		break;
 	case EC_CONFIG_TYPE_UINT64:
-		ret = asprintf(&val_str, "%" PRIi64, value->i64);
+		ret = asprintf(&val_str, "%" PRIu64, value->u64);
 		break;
 	case EC_CONFIG_TYPE_STRING:
 		ret = asprintf(&val_str, "%s", value->string);

--- a/src/dict.c
+++ b/src/dict.c
@@ -2,6 +2,7 @@
  * Copyright 2016, Olivier MATZ <zer0@droids-corp.org>
  */
 
+#include <errno.h>
 #include <fcntl.h>
 #include <stdlib.h>
 #include <string.h>
@@ -17,13 +18,6 @@
 #include "htable_private.h"
 
 EC_LOG_TYPE_REGISTER(dict);
-
-static size_t _strlen(const char *s)
-{
-	if (s == NULL)
-		return 0;
-	return strlen(s);
-}
 
 struct ec_dict_elt {
 	struct ec_htable_elt htable;
@@ -44,22 +38,38 @@ struct ec_dict *ec_dict(void)
 
 bool ec_dict_has_key(const struct ec_dict *dict, const char *key)
 {
-	return ec_htable_has_key(&dict->htable, key, _strlen(key) + 1);
+	if (key == NULL) {
+		errno = EINVAL;
+		return false;
+	}
+	return ec_htable_has_key(&dict->htable, key, strlen(key) + 1);
 }
 
 void *ec_dict_get(const struct ec_dict *dict, const char *key)
 {
-	return ec_htable_get(&dict->htable, key, _strlen(key) + 1);
+	if (key == NULL) {
+		errno = EINVAL;
+		return NULL;
+	}
+	return ec_htable_get(&dict->htable, key, strlen(key) + 1);
 }
 
 int ec_dict_del(struct ec_dict *dict, const char *key)
 {
-	return ec_htable_del(&dict->htable, key, _strlen(key) + 1);
+	if (key == NULL) {
+		errno = EINVAL;
+		return -1;
+	}
+	return ec_htable_del(&dict->htable, key, strlen(key) + 1);
 }
 
 int ec_dict_set(struct ec_dict *dict, const char *key, void *val, ec_dict_elt_free_t free_cb)
 {
-	return ec_htable_set(&dict->htable, key, _strlen(key) + 1, val, free_cb);
+	if (key == NULL) {
+		errno = EINVAL;
+		return -1;
+	}
+	return ec_htable_set(&dict->htable, key, strlen(key) + 1, val, free_cb);
 }
 
 void ec_dict_free(struct ec_dict *dict)

--- a/src/editline.c
+++ b/src/editline.c
@@ -445,7 +445,7 @@ char *ec_editline_gets(struct ec_editline *editline)
 	if (line_copy == NULL)
 		goto fail;
 
-	line_copy[strlen(line_copy) - 1] = '\0'; /* remove \n */
+	line_copy[strcspn(line_copy, "\r\n")] = '\0'; /* strip line end characters */
 
 	if (editline->history != NULL && !ec_str_is_space(line_copy)) {
 		history(editline->history, &editline->histev, H_ENTER, line_copy);

--- a/src/htable.c
+++ b/src/htable.c
@@ -349,6 +349,7 @@ static int ec_htable_init_func(void)
 	ret = read(fd, &ec_htable_seed, sizeof(ec_htable_seed));
 	if (ret != sizeof(ec_htable_seed)) {
 		fprintf(stderr, "failed to read /dev/urandom\n");
+		close(fd);
 		return -1;
 	}
 	close(fd);

--- a/src/interact.c
+++ b/src/interact.c
@@ -451,7 +451,7 @@ int ec_interact_print_error_helps(
 )
 {
 	fprintf(out, "  %s", line);
-	if (line[strlen(line)] != '\n')
+	if (strcspn(line, "\n") == strlen(line))
 		fprintf(out, "\n");
 	fprintf(out, "  %*s^\n", (int)char_idx, "");
 	fprintf(out, "Expected:\n");

--- a/src/node_bypass.c
+++ b/src/node_bypass.c
@@ -182,7 +182,8 @@ struct ec_node *ec_node_bypass(const char *id, struct ec_node *child)
 	if (node == NULL)
 		goto fail;
 
-	ec_node_bypass_set_child(node, child);
+	if (ec_node_bypass_set_child(node, child) < 0)
+		goto fail;
 	child = NULL;
 
 	return node;

--- a/src/node_cmd.c
+++ b/src/node_cmd.c
@@ -312,7 +312,9 @@ static struct ec_node *ec_node_cmd_build_expr(void)
 	);
 	if (ret < 0)
 		goto fail;
-	ec_node_expr_add_parenthesis(expr, ec_node_str(EC_NO_ID, "("), ec_node_str(EC_NO_ID, ")"));
+	ret = ec_node_expr_add_parenthesis(
+		expr, ec_node_str(EC_NO_ID, "("), ec_node_str(EC_NO_ID, ")")
+	);
 	if (ret < 0)
 		goto fail;
 

--- a/src/node_cmd.c
+++ b/src/node_cmd.c
@@ -268,7 +268,7 @@ static int ec_node_cmd_eval_parenthesis(
 static void ec_node_cmd_eval_free(void *result, void *userctx)
 {
 	(void)userctx;
-	free(result);
+	ec_node_free(result);
 }
 
 static const struct ec_node_expr_eval_ops expr_ops = {

--- a/src/node_cond.c
+++ b/src/node_cond.c
@@ -623,7 +623,12 @@ eval_condition(const struct ec_pnode *cond, const struct ec_pnode *pstate)
 
 		iter = ec_pnode_find((void *)arg_list, "id_arg");
 		while (iter != NULL) {
-			args = realloc(args, (n_arg + 1) * sizeof(*args));
+			struct cond_result **tmp;
+
+			tmp = realloc(args, (n_arg + 1) * sizeof(*args));
+			if (tmp == NULL)
+				goto fail;
+			args = tmp;
 			args[n_arg] = eval_condition(iter, pstate);
 			if (args[n_arg] == NULL)
 				goto fail;

--- a/src/node_int.c
+++ b/src/node_int.c
@@ -152,7 +152,7 @@ static int ec_node_int_set_config(struct ec_node *node, const struct ec_config *
 		priv->check_max = true;
 		priv->max = max_value->i64;
 	} else {
-		priv->check_min = false;
+		priv->check_max = false;
 	}
 	if (base_value != NULL)
 		priv->base = base_value->u64;
@@ -262,7 +262,7 @@ static int ec_node_uint_set_config(struct ec_node *node, const struct ec_config 
 		priv->check_max = true;
 		priv->max = max_value->u64;
 	} else {
-		priv->check_min = false;
+		priv->check_max = false;
 	}
 	if (base_value != NULL)
 		priv->base = base_value->u64;

--- a/src/node_once.c
+++ b/src/node_once.c
@@ -223,7 +223,8 @@ struct ec_node *ec_node_once(const char *id, struct ec_node *child)
 	if (node == NULL)
 		goto fail;
 
-	ec_node_once_set_child(node, child);
+	if (ec_node_once_set_child(node, child) < 0)
+		goto fail;
 	child = NULL;
 
 	return node;

--- a/src/node_option.c
+++ b/src/node_option.c
@@ -190,7 +190,8 @@ struct ec_node *ec_node_option(const char *id, struct ec_node *child)
 	if (node == NULL)
 		goto fail;
 
-	ec_node_option_set_child(node, child);
+	if (ec_node_option_set_child(node, child) < 0)
+		goto fail;
 	child = NULL;
 
 	return node;

--- a/src/node_str.c
+++ b/src/node_str.c
@@ -82,6 +82,9 @@ static char *ec_node_str_desc(const struct ec_node *node)
 {
 	struct ec_node_str *priv = ec_node_priv(node);
 
+	if (priv->string == NULL)
+		return NULL;
+
 	return strdup(priv->string);
 }
 

--- a/src/string.c
+++ b/src/string.c
@@ -193,10 +193,13 @@ static int append_token(struct wrap_state *state, const char *token, size_t toke
 
 	/* allocate a larger buffer if needed (the "5" below is a margin above the worst case) */
 	if (state->output == NULL || state->size - state->len < token_len + state->start_off + 5) {
-		size_t new_size;
+		size_t new_size, need;
 		char *tmp;
 
+		need = state->len + token_len + state->start_off + 5;
 		new_size = state->size == 0 ? 256 : state->size * 2;
+		while (new_size < need)
+			new_size *= 2;
 		tmp = malloc(new_size);
 		if (tmp == NULL)
 			return -1;

--- a/src/string.c
+++ b/src/string.c
@@ -161,7 +161,7 @@ char *ec_str_quote(const char *str, char quote, bool force)
 		} else if (!isprint(c) && c != '\n') {
 			char buf[5];
 
-			snprintf(buf, sizeof(buf), "\\x%2.2x", c);
+			snprintf(buf, sizeof(buf), "\\x%2.2x", (unsigned char)c);
 			memcpy(o, buf, 4);
 			o += 4;
 		} else {

--- a/src/strvec.c
+++ b/src/strvec.c
@@ -334,11 +334,12 @@ struct ec_strvec *ec_strvec_sh_lex_str(const char *str, ec_strvec_flag_t flags, 
 
 #define append(buffer, position, character)                                                        \
 	do {                                                                                       \
-		buffer[position++] = character;                                                    \
-		if (position >= sizeof(buffer)) {                                                  \
+		if (position + 1 >= sizeof(buffer)) {                                              \
 			errno = ENOBUFS;                                                           \
 			goto fail;                                                                 \
 		}                                                                                  \
+		buffer[position++] = character;                                                    \
+		buffer[position] = '\0'; /* make sure token is always terminated */                \
 	} while (0)
 
 	if (str == NULL) {
@@ -392,7 +393,6 @@ struct ec_strvec *ec_strvec_sh_lex_str(const char *str, ec_strvec_flag_t flags, 
 			case SPACE:
 				/* end of token */
 				quote = '\0';
-				token[t] = '\0';
 				if (ec_strvec_add(strvec, token) < 0)
 					goto fail;
 				if (sh_lex_set_attrs(
@@ -476,7 +476,6 @@ struct ec_strvec *ec_strvec_sh_lex_str(const char *str, ec_strvec_flag_t flags, 
 		state = IN_WORD;
 	}
 	if (state == IN_WORD && t > 0) {
-		token[t] = '\0';
 		if (ec_strvec_add(strvec, token) < 0)
 			goto fail;
 		if (sh_lex_set_attrs(strvec, ec_strvec_len(strvec) - 1, arg_start, i) < 0)

--- a/src/yaml.c
+++ b/src/yaml.c
@@ -533,12 +533,12 @@ struct ec_node *ec_yaml_import(const char *filename)
 	file = fopen(filename, "rb");
 	if (file == NULL) {
 		fprintf(stderr, "Failed to open file %s\n", filename);
-		goto fail_no_doc;
+		goto fail_no_parser;
 	}
 
 	if (yaml_parser_initialize(&parser) == 0) {
 		fprintf(stderr, "Failed to initialize yaml parser\n");
-		goto fail_no_doc;
+		goto fail_no_parser;
 	}
 
 	yaml_parser_set_input_file(&parser, file);
@@ -570,6 +570,7 @@ fail:
 	yaml_document_delete(&document);
 fail_no_doc:
 	yaml_parser_delete(&parser);
+fail_no_parser:
 	if (file != NULL)
 		fclose(file);
 	free_table(&table);


### PR DESCRIPTION
Fix a batch of bugs found by static analysis across the code base:

* buffer overflows in string formatting and shell lexer
* memory leaks in expression evaluation and realloc error paths
* copy-paste errors in node_int configuration
* missing return value checks
* file descriptor leaks
* NULL pointer dereferences