### PR TITLE
subset: fix false match when no child matches

### DIFF
--- a/src/node_cmd.c
+++ b/src/node_cmd.c
@@ -254,7 +254,10 @@ static int ec_node_cmd_eval_parenthesis(
 			return -1;
 		ec_node_free(in);
 	} else if (!strcmp(ec_strvec_val(vec, 0), "(")) {
-		out = in;
+		out = ec_node_option(EC_NO_ID, ec_node_clone(in));
+		if (out == NULL)
+			return -1;
+		ec_node_free(in);
 	} else {
 		errno = EINVAL;
 		return -1;

--- a/src/node_subset.c
+++ b/src/node_subset.c
@@ -130,9 +130,6 @@ static int ec_node_subset_parse(
 	struct parse_result result;
 	int ret;
 
-	if (ec_strvec_len(strvec) == 0)
-		return EC_PARSE_NOMATCH;
-
 	memset(&result, 0, sizeof(result));
 
 	ret = __ec_node_subset_parse(&result, priv->table, priv->len, pstate, strvec);
@@ -141,7 +138,7 @@ static int ec_node_subset_parse(
 
 	/* if no child node matches, return a matching empty strvec */
 	if (result.parse_len == 0)
-		return 0;
+		return EC_PARSE_NOMATCH;
 
 	return result.len;
 

--- a/test/node_subset.c
+++ b/test/node_subset.c
@@ -27,8 +27,29 @@ EC_TEST_MAIN()
 	testres |= EC_TEST_CHECK_PARSE(node, 1, "foo", "foo");
 	testres |= EC_TEST_CHECK_PARSE(node, 2, "bar", "bar");
 	testres |= EC_TEST_CHECK_PARSE(node, 2, "bar", "foo");
-	testres |= EC_TEST_CHECK_PARSE(node, 0, " ");
-	testres |= EC_TEST_CHECK_PARSE(node, 0, "foox");
+	testres |= EC_TEST_CHECK_PARSE(node, -1, " ");
+	testres |= EC_TEST_CHECK_PARSE(node, -1, "foox");
+	ec_node_free(node);
+
+	/* test that a non-matching subset does not shadow or branches */
+	node = EC_NODE_OR(
+		EC_NO_ID,
+		EC_NODE_SUBSET(
+			EC_NO_ID,
+			ec_node_str(EC_NO_ID, "foo"),
+			ec_node_str(EC_NO_ID, "bar"),
+			ec_node_str(EC_NO_ID, "toto")
+		),
+		ec_node_str(EC_NO_ID, "id")
+	);
+	if (node == NULL) {
+		EC_LOG(EC_LOG_ERR, "cannot create node\n");
+		return -1;
+	}
+	testres |= EC_TEST_CHECK_PARSE(node, 1, "id");
+	testres |= EC_TEST_CHECK_PARSE(node, 1, "foo");
+	testres |= EC_TEST_CHECK_PARSE(node, 2, "foo", "bar");
+	testres |= EC_TEST_CHECK_PARSE(node, -1, "x");
 	ec_node_free(node);
 
 	/* test completion */


### PR DESCRIPTION
When no child of a subset node matches the input, the parse function returns 0 (success, zero tokens consumed) instead of EC_PARSE_NOMATCH. This causes an or node to accept the subset result as a valid match without trying subsequent branches. For example, with the grammar or(subset(vrf, type, internal), seq(id, INT)), parsing "id 42" fails because the or node stops at the subset false success and never reaches the seq(id, INT) branch.

Return EC_PARSE_NOMATCH when result.parse_len is zero. This also makes the earlier strvec empty check redundant since an empty strvec will never match any child, resulting in parse_len zero which now correctly returns EC_PARSE_NOMATCH.

Add an or+subset test case that verifies the second or branch is reachable when the subset does not match.

Fixes: 6a6eea82636b ("subset: require at least one branch")