### PR TITLE
subset: add minimum match count and '&' operator

### DIFF
--- a/include/ecoli/node_subset.h
+++ b/include/ecoli/node_subset.h
@@ -48,6 +48,20 @@ struct ec_node *__ec_node_subset(const char *id, ...);
 struct ec_node *ec_node_subset(const char *id);
 
 /**
+ * Create an empty subset node with a minimum number of children that must match.
+ *
+ * Use ec_node_subset_add() to add children.
+ *
+ * @param id
+ *   The node identifier.
+ * @param min
+ *   The minimum number of children that must match.
+ * @return
+ *   The node, or NULL on error (errno is set).
+ */
+struct ec_node *ec_node_subset_min(const char *id, unsigned int min);
+
+/**
  * Add a child to a subset node.
  *
  * @param node
@@ -59,5 +73,31 @@ struct ec_node *ec_node_subset(const char *id);
  *   0 on success, -1 on error (errno is set).
  */
 int ec_node_subset_add(struct ec_node *node, struct ec_node *child);
+
+/**
+ * Set the minimum number of children that must match.
+ *
+ * By default, a subset node accepts zero matching children. Use this
+ * function to require a minimum number of children to match for the
+ * parse to succeed.
+ *
+ * @param node
+ *   The subset node.
+ * @param min
+ *   The minimum number of children that must match.
+ * @return
+ *   0 on success, -1 on error (errno is set).
+ */
+int ec_node_subset_set_min(struct ec_node *node, unsigned int min);
+
+/**
+ * Get the minimum number of children that must match.
+ *
+ * @param node
+ *   The subset node.
+ * @return
+ *   The minimum number, or 0 if the node is not a subset.
+ */
+unsigned int ec_node_subset_get_min(const struct ec_node *node);
 
 /** @} */

--- a/src/node_cmd.c
+++ b/src/node_cmd.c
@@ -200,12 +200,14 @@ static int ec_node_cmd_eval_bin_op(
 			*result = out;
 		}
 	} else if (!strcmp(ec_strvec_val(vec, 0), ",")) {
-		if (!strcmp(ec_node_get_type_name(in2), "subset")) {
+		if (!strcmp(ec_node_get_type_name(in2), "subset")
+		    && ec_node_subset_get_min(in2) == 1) {
 			if (ec_node_subset_add(in2, ec_node_clone(in1)) < 0)
 				return -1;
 			ec_node_free(in1);
 			*result = in2;
-		} else if (!strcmp(ec_node_get_type_name(in1), "subset")) {
+		} else if (!strcmp(ec_node_get_type_name(in1), "subset")
+			   && ec_node_subset_get_min(in1) == 1) {
 			if (ec_node_subset_add(in1, ec_node_clone(in2)) < 0)
 				return -1;
 			ec_node_free(in2);
@@ -219,6 +221,29 @@ static int ec_node_cmd_eval_bin_op(
 			*result = out;
 		}
 		if (ec_node_subset_set_min(*result, 1) < 0)
+			return -1;
+	} else if (!strcmp(ec_strvec_val(vec, 0), "&")) {
+		if (!strcmp(ec_node_get_type_name(in1), "subset")
+		    && ec_node_subset_get_min(in1) > 1) {
+			if (ec_node_subset_add(in1, ec_node_clone(in2)) < 0)
+				return -1;
+			ec_node_free(in2);
+			*result = in1;
+		} else if (!strcmp(ec_node_get_type_name(in2), "subset")
+			   && ec_node_subset_get_min(in2) > 1) {
+			if (ec_node_subset_add(in2, ec_node_clone(in1)) < 0)
+				return -1;
+			ec_node_free(in1);
+			*result = in2;
+		} else {
+			out = EC_NODE_SUBSET(EC_NO_ID, ec_node_clone(in1), ec_node_clone(in2));
+			if (out == NULL)
+				return -1;
+			ec_node_free(in1);
+			ec_node_free(in2);
+			*result = out;
+		}
+		if (ec_node_subset_set_min(*result, ec_node_get_children_count(*result)) < 0)
 			return -1;
 	} else {
 		errno = EINVAL;
@@ -294,6 +319,9 @@ static struct ec_node *ec_node_cmd_build_expr(void)
 	ret = ec_node_expr_set_val_node(expr, ec_node_re(EC_NO_ID, "[a-zA-Z0-9._-]+"));
 	if (ret < 0)
 		goto fail;
+	ret = ec_node_expr_add_bin_op(expr, ec_node_str(EC_NO_ID, "&"));
+	if (ret < 0)
+		goto fail;
 	ret = ec_node_expr_add_bin_op(expr, ec_node_str(EC_NO_ID, ","));
 	if (ret < 0)
 		goto fail;
@@ -340,7 +368,7 @@ static struct ec_node *ec_node_cmd_build_parser(struct ec_node *expr)
 	ret = ec_node_re_lex_add(lex, "[a-zA-Z0-9._-]+", 1, NULL);
 	if (ret < 0)
 		goto fail;
-	ret = ec_node_re_lex_add(lex, "[*+|,()]", 1, NULL);
+	ret = ec_node_re_lex_add(lex, "[*+|,&()]", 1, NULL);
 	if (ret < 0)
 		goto fail;
 	ret = ec_node_re_lex_add(lex, "\\[", 1, NULL);
@@ -454,11 +482,12 @@ static const struct ec_config_schema ec_node_cmd_schema[] = {
 	{
 		.key = "expr",
 		.desc = "The expression to match. Supported operators "
-			"are or '|', list ',', many '+', many-or-zero '*', "
+			"are or '|', list ',', all '&', many '+', many-or-zero '*', "
 			"option '[]', group '()'. An identifier (alphanumeric) can "
 			"reference a node whose node_id matches. Else it is "
 			"interpreted as ec_node_str() matching this string. "
-			"The ',' operator requires at least one match. "
+			"The ',' operator requires at least one match, "
+			"the '&' operator requires all to match (in any order). "
 			"Example: command [option] (subset1, subset2) x|y",
 		.type = EC_CONFIG_TYPE_STRING,
 	},

--- a/src/node_cmd.c
+++ b/src/node_cmd.c
@@ -218,6 +218,8 @@ static int ec_node_cmd_eval_bin_op(
 			ec_node_free(in2);
 			*result = out;
 		}
+		if (ec_node_subset_set_min(*result, 1) < 0)
+			return -1;
 	} else {
 		errno = EINVAL;
 		return -1;
@@ -456,6 +458,7 @@ static const struct ec_config_schema ec_node_cmd_schema[] = {
 			"option '[]', group '()'. An identifier (alphanumeric) can "
 			"reference a node whose node_id matches. Else it is "
 			"interpreted as ec_node_str() matching this string. "
+			"The ',' operator requires at least one match. "
 			"Example: command [option] (subset1, subset2) x|y",
 		.type = EC_CONFIG_TYPE_STRING,
 	},

--- a/src/node_subset.c
+++ b/src/node_subset.c
@@ -24,6 +24,7 @@ EC_LOG_TYPE_REGISTER(node_subset);
 struct ec_node_subset {
 	struct ec_node **table;
 	unsigned int len;
+	unsigned int min;
 };
 
 struct parse_result {
@@ -136,10 +137,10 @@ static int ec_node_subset_parse(
 	if (ret < 0)
 		goto fail;
 
-	/* if no child node matches, return a matching empty strvec */
-	if (result.parse_len == 0)
-		return 0;
+	if (result.parse_len < priv->min)
+		return EC_PARSE_NOMATCH;
 
+	/* if no child node matches, return a matching empty strvec */
 	return result.len;
 
 fail:
@@ -303,6 +304,43 @@ int ec_node_subset_add(struct ec_node *node, struct ec_node *child)
 fail:
 	ec_node_free(child);
 	return -1;
+}
+
+int ec_node_subset_set_min(struct ec_node *node, unsigned int min)
+{
+	struct ec_node_subset *priv = ec_node_priv(node);
+
+	if (ec_node_check_type(node, &ec_node_subset_type) < 0)
+		return -1;
+
+	priv->min = min;
+
+	return 0;
+}
+
+unsigned int ec_node_subset_get_min(const struct ec_node *node)
+{
+	const struct ec_node_subset *priv = ec_node_priv(node);
+
+	if (ec_node_check_type(node, &ec_node_subset_type) < 0)
+		return 0;
+
+	return priv->min;
+}
+
+struct ec_node *ec_node_subset_min(const char *id, unsigned int min)
+{
+	struct ec_node_subset *priv;
+	struct ec_node *node;
+
+	node = ec_node_from_type(&ec_node_subset_type, id);
+	if (node == NULL)
+		return NULL;
+
+	priv = ec_node_priv(node);
+	priv->min = min;
+
+	return node;
 }
 
 struct ec_node *__ec_node_subset(const char *id, ...)

--- a/src/node_subset.c
+++ b/src/node_subset.c
@@ -130,9 +130,6 @@ static int ec_node_subset_parse(
 	struct parse_result result;
 	int ret;
 
-	if (ec_strvec_len(strvec) == 0)
-		return EC_PARSE_NOMATCH;
-
 	memset(&result, 0, sizeof(result));
 
 	ret = __ec_node_subset_parse(&result, priv->table, priv->len, pstate, strvec);

--- a/test/node_cmd.c
+++ b/test/node_cmd.c
@@ -11,7 +11,7 @@ EC_TEST_MAIN()
 
 	node = EC_NODE_CMD(
 		EC_NO_ID,
-		"command [option] (subset1, subset2, subset3, subset4) x|y z*",
+		"command [option] [subset1, subset2, subset3, subset4] x|y z*",
 		ec_node_int("x", 0, 10, 10),
 		ec_node_int("y", 20, 30, 10)
 	);
@@ -31,6 +31,18 @@ EC_TEST_MAIN()
 	testres |= EC_TEST_CHECK_PARSE(node, 5, "command", "option", "23", "z", "z");
 	testres |= EC_TEST_CHECK_PARSE(node, -1, "command", "15");
 	testres |= EC_TEST_CHECK_PARSE(node, -1, "foo");
+	ec_node_free(node);
+
+	/* test ',' operator: at least one element required */
+	node = EC_NODE_CMD(EC_NO_ID, "command foo, bar, toto end");
+	if (node == NULL) {
+		EC_LOG(EC_LOG_ERR, "cannot create node\n");
+		return -1;
+	}
+	testres |= EC_TEST_CHECK_PARSE(node, 5, "command", "foo", "bar", "toto", "end");
+	testres |= EC_TEST_CHECK_PARSE(node, 3, "command", "foo", "end");
+	testres |= EC_TEST_CHECK_PARSE(node, 4, "command", "bar", "foo", "end");
+	testres |= EC_TEST_CHECK_PARSE(node, -1, "command", "end");
 	ec_node_free(node);
 
 	node = EC_NODE_CMD(

--- a/test/node_cmd.c
+++ b/test/node_cmd.c
@@ -33,6 +33,20 @@ EC_TEST_MAIN()
 	testres |= EC_TEST_CHECK_PARSE(node, -1, "foo");
 	ec_node_free(node);
 
+	/* test '&' operator: all elements required in any order */
+	node = EC_NODE_CMD(EC_NO_ID, "command foo & bar & toto end");
+	if (node == NULL) {
+		EC_LOG(EC_LOG_ERR, "cannot create node\n");
+		return -1;
+	}
+	testres |= EC_TEST_CHECK_PARSE(node, 5, "command", "foo", "bar", "toto", "end");
+	testres |= EC_TEST_CHECK_PARSE(node, 5, "command", "toto", "foo", "bar", "end");
+	testres |= EC_TEST_CHECK_PARSE(node, 5, "command", "bar", "toto", "foo", "end");
+	testres |= EC_TEST_CHECK_PARSE(node, -1, "command", "foo", "bar", "end");
+	testres |= EC_TEST_CHECK_PARSE(node, -1, "command", "foo", "end");
+	testres |= EC_TEST_CHECK_PARSE(node, -1, "command", "end");
+	ec_node_free(node);
+
 	/* test ',' operator: at least one element required */
 	node = EC_NODE_CMD(EC_NO_ID, "command foo, bar, toto end");
 	if (node == NULL) {

--- a/test/node_subset.c
+++ b/test/node_subset.c
@@ -31,6 +31,73 @@ EC_TEST_MAIN()
 	testres |= EC_TEST_CHECK_PARSE(node, 0, "foox");
 	ec_node_free(node);
 
+	/* test with min=1 (at least one child must match) */
+	node = EC_NODE_SUBSET(
+		EC_NO_ID,
+		ec_node_str(EC_NO_ID, "foo"),
+		ec_node_str(EC_NO_ID, "bar"),
+		ec_node_str(EC_NO_ID, "toto")
+	);
+	if (node == NULL) {
+		EC_LOG(EC_LOG_ERR, "cannot create node\n");
+		return -1;
+	}
+	ec_node_subset_set_min(node, 1);
+	testres |= EC_TEST_CHECK_PARSE(node, -1);
+	testres |= EC_TEST_CHECK_PARSE(node, 1, "foo");
+	testres |= EC_TEST_CHECK_PARSE(node, 2, "foo", "bar");
+	testres |= EC_TEST_CHECK_PARSE(node, 3, "bar", "foo", "toto");
+	testres |= EC_TEST_CHECK_PARSE(node, -1, "x");
+	ec_node_free(node);
+
+	/* test with min=len (all children must match) */
+	node = EC_NODE_SUBSET(
+		EC_NO_ID,
+		ec_node_str(EC_NO_ID, "foo"),
+		ec_node_str(EC_NO_ID, "bar"),
+		ec_node_str(EC_NO_ID, "toto")
+	);
+	if (node == NULL) {
+		EC_LOG(EC_LOG_ERR, "cannot create node\n");
+		return -1;
+	}
+	ec_node_subset_set_min(node, 3);
+	testres |= EC_TEST_CHECK_PARSE(node, -1);
+	testres |= EC_TEST_CHECK_PARSE(node, -1, "foo");
+	testres |= EC_TEST_CHECK_PARSE(node, -1, "foo", "bar");
+	testres |= EC_TEST_CHECK_PARSE(node, 3, "bar", "foo", "toto");
+	testres |= EC_TEST_CHECK_PARSE(node, 3, "toto", "bar", "foo");
+	testres |= EC_TEST_CHECK_PARSE(node, 3, "foo", "toto", "bar", "x");
+	testres |= EC_TEST_CHECK_PARSE(node, -1, "x");
+	ec_node_free(node);
+
+	/* test that a non-matching subset with min=1 does not shadow or branches */
+	{
+		struct ec_node *subset;
+
+		subset = EC_NODE_SUBSET(
+			EC_NO_ID,
+			ec_node_str(EC_NO_ID, "foo"),
+			ec_node_str(EC_NO_ID, "bar"),
+			ec_node_str(EC_NO_ID, "toto")
+		);
+		if (subset == NULL) {
+			EC_LOG(EC_LOG_ERR, "cannot create node\n");
+			return -1;
+		}
+		ec_node_subset_set_min(subset, 1);
+		node = EC_NODE_OR(EC_NO_ID, subset, ec_node_str(EC_NO_ID, "id"));
+		if (node == NULL) {
+			EC_LOG(EC_LOG_ERR, "cannot create node\n");
+			return -1;
+		}
+		testres |= EC_TEST_CHECK_PARSE(node, 1, "id");
+		testres |= EC_TEST_CHECK_PARSE(node, 1, "foo");
+		testres |= EC_TEST_CHECK_PARSE(node, 2, "foo", "bar");
+		testres |= EC_TEST_CHECK_PARSE(node, -1, "x");
+		ec_node_free(node);
+	}
+
 	/* test completion */
 	node = EC_NODE_SUBSET(
 		EC_NO_ID,

--- a/test/node_subset.c
+++ b/test/node_subset.c
@@ -19,7 +19,7 @@ EC_TEST_MAIN()
 		EC_LOG(EC_LOG_ERR, "cannot create node\n");
 		return -1;
 	}
-	testres |= EC_TEST_CHECK_PARSE(node, -1);
+	testres |= EC_TEST_CHECK_PARSE(node, 0);
 	testres |= EC_TEST_CHECK_PARSE(node, 1, "foo");
 	testres |= EC_TEST_CHECK_PARSE(node, 1, "bar");
 	testres |= EC_TEST_CHECK_PARSE(node, 2, "foo", "bar", "titi");


### PR DESCRIPTION
Add a min field to the subset node so that it can require a minimum number of children to match. When the number of matched children is below min, return EC_PARSE_NOMATCH instead of accepting zero matches.

In ec_node_cmd expressions, the ',' operator now sets min=1 on the subset it creates, requiring at least one child to match. This fixes a bug where a non-matching subset would shadow subsequent branches in an or node by falsely returning success with zero consumed tokens.

A new '&' binary operator creates a subset with min equal to the number of children, requiring all elements to match in any order. For example, "cmd foo & bar & baz end" accepts any permutation of foo, bar and baz before end, but rejects partial matches.

Supersedes #34.