### PR TITLE
devtools: check for missing symbol definitions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -28,6 +28,7 @@ jobs:
           set -xe
           sudo apt-get update -qy
           sudo apt-get install -qy --no-install-recommends \
+            clang \
             doxygen \
             gcc \
             gcovr \
@@ -39,7 +40,8 @@ jobs:
             libyaml-dev \
             meson \
             ninja-build \
-            pkg-config
+            pkg-config \
+            python3
       - uses: actions/checkout@v4
         with:
           persist-credentials: false

--- a/devtools/gen_sym_check.py
+++ b/devtools/gen_sym_check.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2026 Robin Jarry
+
+"""
+Generate a C file that references all function and variable declarations from
+project headers. This ensures the linker will complain if any declared symbol
+is missing a definition.
+"""
+
+import argparse
+import json
+import subprocess
+
+
+def is_project_header(path: str, excludes: list[str]) -> bool:
+    if not path:
+        return False
+    if path.startswith("/usr"):
+        return False
+    if path.endswith(".c"):
+        return False
+    for exc in excludes:
+        if path.endswith(exc):
+            return False
+    return True
+
+
+def get_effective_file(node: dict, current_file: str) -> str:
+    loc = node.get("loc", {})
+
+    range_file = node.get("range", {}).get("begin", {}).get("file", "")
+    if range_file:
+        return range_file
+
+    f = loc.get("file", "")
+    if f:
+        return f
+
+    f = loc.get("expansionLoc", {}).get("file", "")
+    if f:
+        return f
+
+    return current_file
+
+
+def update_current_file(node: dict, current_file: str) -> str:
+    loc = node.get("loc", {})
+    f = loc.get("file", "")
+    if f:
+        return f
+    f = node.get("range", {}).get("begin", {}).get("file", "")
+    if f:
+        return f
+    return current_file
+
+
+def extract_symbols(ast: dict, excludes: list[str]) -> tuple[list[str], list[str]]:
+    funcs = []
+    variables = []
+    current_file = ""
+
+    for node in ast.get("inner", []):
+        effective_file = get_effective_file(node, current_file)
+        current_file = update_current_file(node, current_file)
+
+        kind = node.get("kind")
+        name = node.get("name", "")
+
+        if not is_project_header(effective_file, excludes):
+            continue
+        if name.startswith("_"):
+            continue
+
+        if kind == "FunctionDecl":
+            if node.get("storageClass", "") == "static":
+                continue
+            funcs.append(name)
+
+        elif kind == "VarDecl":
+            if node.get("storageClass", "") == "extern":
+                variables.append(name)
+
+    return sorted(set(funcs)), sorted(set(variables))
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("include_dir")
+    parser.add_argument("--exclude", action="append", default=[])
+    args = parser.parse_args()
+
+    # Dump the AST in JSON format.
+    cmd = (
+        "clang",
+        "-Xclang",
+        "-ast-dump=json",
+        "-fsyntax-only",
+        "-I" + args.include_dir,
+        "-x",
+        "c",
+        "-",
+    )
+    result = subprocess.run(
+        cmd, capture_output=True, text=True, input="#include <ecoli.h>\n"
+    )
+    if result.returncode != 0:
+        parser.error(result.stderr)
+
+    # Extract all ecoli symbols from the AST
+    ast = json.loads(result.stdout)
+    funcs, variables = extract_symbols(ast, args.exclude)
+
+    # Generate a dummy C source file that references all declared symbols in
+    # ecoli headers.
+    print("/* Auto-generated - do not edit. */")
+    print()
+    print("#include <ecoli.h>")
+    print("#include <stdio.h>")
+    print()
+    print("static void *syms[] = {")
+    for f in funcs:
+        print(f"\t(void *){f},")
+    for v in variables:
+        print(f"\t(void *)&{v},")
+    print("};")
+    print()
+    print("int main(void)")
+    print("{")
+    print("\tfor (unsigned i = 0; i < sizeof(syms) / sizeof(syms[0]); i++)")
+    print('\t\tprintf("%p\\n", syms[i]);')
+    print("\treturn 0;")
+    print("}")
+
+
+if __name__ == "__main__":
+    main()

--- a/meson.build
+++ b/meson.build
@@ -50,6 +50,33 @@ else
 		description : 'Extensible COmmand LIne library.')
 endif
 
+if find_program('clang').found() and find_program('python').found()
+	sym_check_cmd = [
+		files('devtools/gen_sym_check.py'),
+		meson.current_source_dir() / 'include',
+	]
+	if not yaml_dep.found()
+		sym_check_cmd += ['--exclude', 'ecoli/yaml.h']
+	endif
+	if not edit_dep.found()
+		sym_check_cmd += ['--exclude', 'ecoli/editline.h']
+	endif
+	sym_check_c = custom_target('sym_check.c',
+		output : 'sym_check.c',
+		capture : true,
+		command : sym_check_cmd,
+		depend_files : doc_sources,
+	)
+	executable('sym_check',
+		sym_check_c,
+		include_directories : inc,
+		link_with : libecoli,
+		dependencies : deps,
+		build_by_default : true,
+		install : false,
+	)
+endif
+
 subdir('test')
 subdir('examples')
 subdir('doc')

--- a/src/node_expr.c
+++ b/src/node_expr.c
@@ -267,6 +267,11 @@ static struct ec_node_type ec_node_expr_type = {
 
 EC_NODE_TYPE_REGISTER(ec_node_expr_type);
 
+struct ec_node *ec_node_expr(const char *id)
+{
+	return ec_node_from_type(&ec_node_expr_type, id);
+}
+
 int ec_node_expr_set_val_node(struct ec_node *node, struct ec_node *val_node)
 {
 	struct ec_node_expr *priv = ec_node_priv(node);

--- a/src/node_or.c
+++ b/src/node_or.c
@@ -157,6 +157,11 @@ static struct ec_node_type ec_node_or_type = {
 
 EC_NODE_TYPE_REGISTER(ec_node_or_type);
 
+struct ec_node *ec_node_or(const char *id)
+{
+	return ec_node_from_type(&ec_node_or_type, id);
+}
+
 int ec_node_or_add(struct ec_node *node, struct ec_node *child)
 {
 	const struct ec_config *cur_config = NULL;

--- a/src/node_seq.c
+++ b/src/node_seq.c
@@ -243,6 +243,11 @@ static struct ec_node_type ec_node_seq_type = {
 
 EC_NODE_TYPE_REGISTER(ec_node_seq_type);
 
+struct ec_node *ec_node_seq(const char *id)
+{
+	return ec_node_from_type(&ec_node_seq_type, id);
+}
+
 int ec_node_seq_add(struct ec_node *node, struct ec_node *child)
 {
 	const struct ec_config *cur_config = NULL;

--- a/src/node_subset.c
+++ b/src/node_subset.c
@@ -274,6 +274,11 @@ static struct ec_node_type ec_node_subset_type = {
 
 EC_NODE_TYPE_REGISTER(ec_node_subset_type);
 
+struct ec_node *ec_node_subset(const char *id)
+{
+	return ec_node_from_type(&ec_node_subset_type, id);
+}
+
 int ec_node_subset_add(struct ec_node *node, struct ec_node *child)
 {
 	struct ec_node_subset *priv = ec_node_priv(node);


### PR DESCRIPTION
Add convenience constructors for the expr, or, seq, and subset node types. These are declared in the public headers but have no definition.

Also add a build-time check that ensures all symbols declared in public headers have a corresponding definition. A python script uses clang to dump the AST of ecoli.h, extracts all non-static function declarations and extern variable declarations, and generates a C source file that takes the address of every declared symbol. The generated file is compiled and linked against libecoli via meson, so any missing definition will cause a linker error at build time.