### PR TITLE
editline: add deprecated aliases for symbols moved to interact.h

### DIFF
--- a/include/ecoli/editline.h
+++ b/include/ecoli/editline.h
@@ -26,14 +26,6 @@ struct editline;
 struct ec_editline;
 
 /**
- * A structure describing a contextual help.
- */
-struct ec_editline_help {
-	char *desc; /**< The short description of the item. */
-	char *help; /**< The associated help. */
-};
-
-/**
  * Default history size.
  */
 #define EC_EDITLINE_HISTORY_SIZE 128
@@ -331,5 +323,88 @@ int ec_editline_interact(
  *   An editline error code: CC_REFRESH, CC_ERROR, or CC_REDISPLAY.
  */
 int ec_editline_complete(struct editline *el, int c);
+
+/*
+ * Deprecated aliases for symbols moved to interact.h.
+ */
+
+#include "interact.h"
+#include "utils.h"
+
+/** @cond DEPRECATED */
+
+#define EC_EDITLINE_HELP_ATTR EC_DEPRECATED_MACRO("use EC_INTERACT_HELP_ATTR") EC_INTERACT_HELP_ATTR
+#define EC_EDITLINE_CB_ATTR EC_DEPRECATED_MACRO("use EC_INTERACT_CB_ATTR") EC_INTERACT_CB_ATTR
+#define EC_EDITLINE_DESC_ATTR EC_DEPRECATED_MACRO("use EC_INTERACT_DESC_ATTR") EC_INTERACT_DESC_ATTR
+
+struct EC_DEPRECATED("use struct ec_interact_help") ec_editline_help {
+	char *desc;
+	char *help;
+};
+
+typedef ec_interact_command_cb_t
+	ec_editline_command_cb_t EC_DEPRECATED("use ec_interact_command_cb_t");
+
+/*
+ * Suppress deprecation warnings for function declarations that reference
+ * deprecated types in their signatures.
+ */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
+EC_DEPRECATED("use ec_interact_get_completions") ssize_t
+ec_editline_get_completions(const struct ec_comp *cmpl, char ***matches_out);
+
+EC_DEPRECATED("use ec_interact_free_completions")
+void ec_editline_free_completions(char **matches, size_t n);
+
+EC_DEPRECATED("use ec_interact_print_cols")
+int ec_editline_print_cols(struct ec_editline *editline, char const *const *matches, size_t n);
+
+EC_DEPRECATED("use ec_interact_append_chars")
+char *ec_editline_append_chars(const struct ec_comp *cmpl);
+
+EC_DEPRECATED("use ec_interact_get_helps") ssize_t ec_editline_get_helps(
+	const struct ec_editline *editline,
+	const char *line,
+	struct ec_editline_help **helps_out
+);
+
+EC_DEPRECATED("use ec_interact_print_helps")
+int ec_editline_print_helps(
+	const struct ec_editline *editline,
+	const struct ec_editline_help *helps,
+	size_t n
+);
+
+EC_DEPRECATED("use ec_interact_free_helps")
+void ec_editline_free_helps(struct ec_editline_help *helps, size_t n);
+
+EC_DEPRECATED("use ec_interact_get_error_helps") ssize_t ec_editline_get_error_helps(
+	const struct ec_editline *editline,
+	struct ec_editline_help **helps_out,
+	size_t *char_idx
+);
+
+EC_DEPRECATED("use ec_interact_print_error_helps")
+int ec_editline_print_error_helps(
+	const struct ec_editline *editline,
+	const struct ec_editline_help *helps,
+	size_t n,
+	size_t char_idx
+);
+
+EC_DEPRECATED("use ec_interact_set_help")
+int ec_editline_set_help(struct ec_node *node, const char *help);
+
+EC_DEPRECATED("use ec_interact_set_callback")
+int ec_editline_set_callback(struct ec_node *node, ec_interact_command_cb_t cb);
+
+EC_DEPRECATED("use ec_interact_set_desc")
+int ec_editline_set_desc(struct ec_node *node, const char *desc);
+
+#pragma GCC diagnostic pop
+
+/** @endcond */
 
 /** @} */

--- a/include/ecoli/utils.h
+++ b/include/ecoli/utils.h
@@ -30,4 +30,15 @@
  */
 #define EC_COUNT_OF(x) ((sizeof(x) / sizeof(0 [x])) / ((size_t)(!(sizeof(x) % sizeof(0 [x])))))
 
+/**
+ * Mark a function or type as deprecated.
+ */
+#define EC_DEPRECATED(msg) __attribute__((deprecated(msg)))
+
+/**
+ * Emit a deprecation warning when a macro is expanded.
+ */
+#define EC_DEPRECATED_MACRO_(x) _Pragma(#x)
+#define EC_DEPRECATED_MACRO(msg) EC_DEPRECATED_MACRO_(GCC warning msg)
+
 /** @} */

--- a/meson.build
+++ b/meson.build
@@ -72,6 +72,7 @@ if find_program('clang', required: false).found() and find_program('python', req
 		include_directories : inc,
 		link_with : libecoli,
 		dependencies : deps,
+		c_args : ['-Wno-deprecated-declarations'],
 		build_by_default : true,
 		install : false,
 	)

--- a/src/editline.c
+++ b/src/editline.c
@@ -488,6 +488,159 @@ fail:
 	return NULL;
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
+/* Deprecated wrappers for symbols moved to interact.h. */
+
+ssize_t ec_editline_get_completions(const struct ec_comp *cmpl, char ***matches_out)
+{
+	return ec_interact_get_completions(cmpl, matches_out, EC_COMP_FULL | EC_COMP_PARTIAL);
+}
+
+void ec_editline_free_completions(char **matches, size_t n)
+{
+	ec_interact_free_completions(matches, n);
+}
+
+int ec_editline_print_cols(struct ec_editline *editline, char const *const *matches, size_t n)
+{
+	unsigned int width = 80, height;
+	FILE *out;
+
+	if (el_get(editline->el, EL_GETFP, 1, &out))
+		return -1;
+
+	ec_editline_term_size(editline, &width, &height);
+
+	return ec_interact_print_cols(out, width, matches, n);
+}
+
+char *ec_editline_append_chars(const struct ec_comp *cmpl)
+{
+	return ec_interact_append_chars(cmpl);
+}
+
+ssize_t ec_editline_get_helps(
+	const struct ec_editline *editline,
+	const char *line,
+	struct ec_editline_help **helps_out
+)
+{
+	char *curline = NULL;
+	ssize_t ret;
+
+	if (line == NULL) {
+		curline = ec_editline_curline(editline, true);
+		if (curline == NULL)
+			return -1;
+		line = curline;
+	}
+
+	ret = ec_interact_get_helps(editline->node, line, (struct ec_interact_help **)helps_out);
+	free(curline);
+	return ret;
+}
+
+int ec_editline_print_helps(
+	const struct ec_editline *editline,
+	const struct ec_editline_help *helps,
+	size_t n
+)
+{
+	unsigned int width = 80, height;
+	FILE *out;
+
+	if (el_get(editline->el, EL_GETFP, 1, &out))
+		return -1;
+
+	ec_editline_term_size(editline, &width, &height);
+	if (width > 100)
+		width = 100;
+	if (width < 50)
+		width = 50;
+
+	return ec_interact_print_helps(out, width, (const struct ec_interact_help *)helps, n);
+}
+
+void ec_editline_free_helps(struct ec_editline_help *helps, size_t n)
+{
+	ec_interact_free_helps((struct ec_interact_help *)helps, n);
+}
+
+ssize_t ec_editline_get_error_helps(
+	const struct ec_editline *editline,
+	struct ec_editline_help **helps_out,
+	size_t *char_idx
+)
+{
+	char *line;
+
+	if (editline == NULL || helps_out == NULL) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	line = ec_editline_curline(editline, false);
+	if (line == NULL)
+		return 0;
+
+	ssize_t ret = ec_interact_get_error_helps(
+		editline->node, line, (struct ec_interact_help **)helps_out, char_idx
+	);
+	free(line);
+	return ret;
+}
+
+int ec_editline_print_error_helps(
+	const struct ec_editline *editline,
+	const struct ec_editline_help *helps,
+	size_t n,
+	size_t char_idx
+)
+{
+	unsigned int width = 80, height;
+	char *line = NULL;
+	FILE *out;
+	int ret;
+
+	if (el_get(editline->el, EL_GETFP, 1, &out))
+		return -1;
+
+	ec_editline_term_size(editline, &width, &height);
+	if (width > 100)
+		width = 100;
+	if (width < 50)
+		width = 50;
+
+	line = ec_editline_curline(editline, false);
+	if (line == NULL)
+		return -1;
+
+	ret = ec_interact_print_error_helps(
+		out, width, line, (const struct ec_interact_help *)helps, n, char_idx
+	);
+	free(line);
+	return ret;
+}
+
+int ec_editline_set_help(struct ec_node *node, const char *help)
+{
+	return ec_interact_set_help(node, help);
+}
+
+int ec_editline_set_callback(struct ec_node *node, ec_interact_command_cb_t cb)
+{
+	return ec_interact_set_callback(node, cb);
+}
+
+int ec_editline_set_desc(struct ec_node *node, const char *desc)
+{
+	return ec_interact_set_desc(node, desc);
+}
+
+#pragma GCC diagnostic pop
+
 int ec_editline_interact(
 	struct ec_editline *editline,
 	ec_editline_check_exit_cb_t check_exit_cb,


### PR DESCRIPTION
Commit bc90312a4285 ("editline: split in 2 files") moved several public symbols from editline.h to interact.h under new names (ec_editline_* to ec_interact_*). This is a breaking API change for downstream projects.

Re-introduce the old ec_editline_* names as deprecated wrappers so that existing code continues to compile with deprecation warnings instead of hard errors. Functions whose signature changed (different parameter types) are implemented as actual wrappers in editline.c that bridge between the old ec_editline-based API and the new ec_interact one.

Also remove -Wdeprecated-declarations in the generated symbol check file, since it references all public symbols including deprecated ones.