### PR TITLE
doc: generate man pages with doxygen2man

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -38,6 +38,7 @@ jobs:
             clang \
             curl \
             doxygen \
+            doxygen2man \
             gcc \
             gcovr \
             graphviz \
@@ -45,6 +46,7 @@ jobs:
             libc-dev \
             libedit-dev \
             libreadline-dev \
+            libxml2-utils \
             libyaml-dev \
             meson \
             ninja-build \
@@ -80,7 +82,15 @@ jobs:
           set -xe
           sudo apt-get update -qy
           sudo apt-get install -qy --no-install-recommends \
-            doxygen gcc graphviz libc-dev meson ninja-build pkg-config
+            doxygen \
+            doxygen2man \
+            gcc \
+            graphviz \
+            libc-dev \
+            libxml2-utils \
+            meson \
+            ninja-build \
+            pkg-config
       - uses: actions/checkout@v6
         with:
           persist-credentials: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,17 @@ jobs:
       contents: read
     steps:
       - name: install system dependencies
-        run: dnf install -y --nodocs --setopt=install_weak_deps=0 doxygen gcc graphviz make meson ninja-build pkgconf
+        run: |
+          dnf install -y --nodocs --setopt=install_weak_deps=0 \
+            doxygen \
+            doxygen2man \
+            gcc \
+            graphviz \
+            libxml2 \
+            make \
+            meson \
+            ninja-build \
+            pkgconf
       - uses: actions/checkout@v6
       - uses: actions/configure-pages@v6
       - run: make

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -26,7 +26,9 @@ GENERATE_DEPRECATEDLIST = YES
 INTERNAL_DOCS           = NO
 VERBATIM_HEADERS        = NO
 ALPHABETICAL_INDEX      = NO
-FULL_PATH_NAMES         = NO
+FULL_PATH_NAMES         = YES
+STRIP_FROM_PATH         = @TOPDIR@/include
+STRIP_FROM_INC_PATH     = @TOPDIR@/include
 WARN_AS_ERROR           = NO
 MARKDOWN_SUPPORT        = YES
 
@@ -41,9 +43,8 @@ SORT_MEMBER_DOCS        = NO
 SOURCE_BROWSER          = YES
 
 GENERATE_HTML           = @GENERATE_HTML@
-GENERATE_XML            = NO
+GENERATE_XML            = @GENERATE_XML@
 GENERATE_LATEX          = NO
-GENERATE_MAN            = @GENERATE_MAN@
+GENERATE_MAN            = NO
 
-MAN_LINKS               = YES
-MAN_OUTPUT              = man
+XML_OUTPUT              = xml

--- a/doc/gen-man-pages.sh
+++ b/doc/gen-man-pages.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2026 Robin Jarry
+#
+# Generate man pages from doxygen XML using doxygen2man.
+# Usage: gen-man-pages.sh <xml-dir> <include-dir> <output-dir> <stamp-file>
+
+set -e
+
+xml_dir="$1"
+include_dir="$2"
+output_dir="$3"
+stamp="$4"
+
+if [ -z "$xml_dir" ] || [ -z "$include_dir" ] || \
+   [ -z "$output_dir" ] || [ -z "$stamp" ]; then
+	echo "usage: $0 <xml-dir> <include-dir> <output-dir> <stamp-file>" >&2
+	exit 1
+fi
+
+mkdir -p "$output_dir"
+
+# Extract group XML filenames from the doxygen index.
+groups=$(xmllint --xpath '//compound[@kind="group"]/@refid' \
+	"$xml_dir/index.xml" | sed 's/ *refid="\([^"]*\)"/\1.xml/g')
+if [ -z "$groups" ]; then
+	echo "error: no groups found in $xml_dir/index.xml" >&2
+	exit 1
+fi
+
+for xml in $groups; do
+	doxygen2man -m -p libecoli -s 3 \
+		-H "Libecoli Programmer's Manual" \
+		-C "Olivier Matz" \
+		-S "2010" \
+		-d "$xml_dir" \
+		-o "$output_dir" \
+		"$xml"
+done
+
+# Fix include paths in generated man pages.
+xpath='string(//memberdef[@kind="function"][name="%s"]/location/@file)'
+for manpage in "$output_dir"/*.3; do
+	[ -f "$manpage" ] || continue
+	func_name=$(basename -s .3 "$manpage")
+	inc=$(xmllint --xpath "$(printf "$xpath" "$func_name")" \
+		"$xml_dir"/group__*.xml 2>/dev/null | xargs echo)
+	if [ -n "$inc" ]; then
+		sed -i "s|^\.B #include <.*>|.B #include <${inc}>|" "$manpage"
+	fi
+done
+
+# Strip the systematic ", Inc. All rights reserved." suffix to all copyrights
+sed -i 's/, Inc\. All rights reserved\.//' "$output_dir"/*.3
+
+touch "$stamp"

--- a/doc/install-man-pages.sh
+++ b/doc/install-man-pages.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2026 Robin Jarry
+#
+# Install generated man pages. Called by meson.add_install_script().
+
+set -e
+
+man_dir="$1"
+mandir="$2"
+
+# mandir may be relative (e.g. "share/man"), resolve against install prefix.
+case "$mandir" in
+/*)
+	dest="${DESTDIR}${mandir}/man3"
+	;;
+*)
+	dest="${MESON_INSTALL_DESTDIR_PREFIX}/${mandir}/man3"
+	;;
+esac
+
+install -m 644 -Dvt "$dest" "$man_dir"/*.3

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -2,6 +2,8 @@
 # Copyright 2019, Olivier MATZ <zer0@droids-corp.org>
 
 doxygen = find_program('doxygen', required: get_option('doc'))
+doxygen2man = find_program('doxygen2man', required: get_option('doc'))
+xmllint = find_program('xmllint', required: get_option('doc'))
 if not doxygen.found()
   subdir_done()
 endif
@@ -24,31 +26,52 @@ node_schemas = custom_target(
 	command: [ecoli_gen_node_schema, meson.current_build_dir(), '@OUTPUT@'],
 )
 
-man_cdata = configuration_data()
-man_cdata.merge_from(cdata)
-man_cdata.set('GENERATE_HTML', 'NO')
-man_cdata.set('GENERATE_MAN', 'YES')
-man_cdata.set('EXAMPLES_INPUT', '')
-doxygen_man_conf = configure_file(
-	input: 'Doxyfile.in',
-	output: 'Doxyfile.man',
-	configuration: man_cdata,
-	install: false)
-custom_target(
-	'doxygen-man',
-	input: doxygen_man_conf,
-	output: 'man',
-	command: [doxygen, '@INPUT@'],
-	build_by_default: true,
-	depends: node_schemas,
-	depend_files: doc_sources,
-	install: true,
-	install_dir: get_option('datadir'))
+if doxygen2man.found() and xmllint.found()
+	xml_cdata = configuration_data()
+	xml_cdata.merge_from(cdata)
+	xml_cdata.set('GENERATE_HTML', 'NO')
+	xml_cdata.set('GENERATE_XML', 'YES')
+	xml_cdata.set('EXAMPLES_INPUT', '')
+	doxygen_xml_conf = configure_file(
+		input: 'Doxyfile.in',
+		output: 'Doxyfile.xml',
+		configuration: xml_cdata,
+		install: false)
+	doxygen_xml = custom_target(
+		'doxygen-xml',
+		input: doxygen_xml_conf,
+		output: 'xml',
+		command: [doxygen, '@INPUT@'],
+		build_by_default: true,
+		depends: node_schemas,
+		depend_files: doc_sources,
+		install: false)
+
+	custom_target(
+		'man-pages',
+		output: 'man-pages.stamp',
+		command: [
+			files('gen-man-pages.sh'),
+			meson.current_build_dir() / 'xml',
+			meson.project_source_root() / 'include',
+			meson.current_build_dir() / 'man',
+			'@OUTPUT@',
+		],
+		depends: doxygen_xml,
+		depend_files: doc_sources,
+		build_by_default: true,
+		install: false)
+
+	meson.add_install_script(
+		files('install-man-pages.sh'),
+		meson.current_build_dir() / 'man',
+		get_option('mandir'))
+endif
 
 html_cdata = configuration_data()
 html_cdata.merge_from(cdata)
 html_cdata.set('GENERATE_HTML', 'YES')
-html_cdata.set('GENERATE_MAN', 'NO')
+html_cdata.set('GENERATE_XML', 'NO')
 html_cdata.set('EXAMPLES_INPUT', meson.project_source_root() / 'examples')
 doxygen_html_conf = configure_file(
 	input: 'Doxyfile.in',


### PR DESCRIPTION
Replace the doxygen built-in man page generator with doxygen2man which produces one self-contained man page per function with proper SYNOPSIS, PARAMS, DESCRIPTION and RETURN VALUE sections.

Generate doxygen XML output instead of man output and feed the group XML files to doxygen2man via a wrapper script. Post-process the generated pages to fix include paths and strip the hardcoded copyright suffix.

Enable FULL_PATH_NAMES with STRIP_FROM_INC_PATH so that doxygen XML contains proper relative include paths (e.g. ecoli/node.h).