### PR TITLE
doc: enable automatic @brief for all symbols

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -12,7 +12,7 @@ IMAGE_PATH             = @TOPDIR@/doc
 
 EXCLUDE_SYMBOLS        = __* TAILQ_* free* init* realloc malloc boolean complete desc dict u64 test type size string subschema parse node name list key i64 help set_config schema priority exit get_child get_children_count eval_* @1* @3* lstat opendir readdir closedir dirfd fstatat ip_pool*
 
-
+JAVADOC_AUTOBRIEF       = YES
 OPTIMIZE_OUTPUT_FOR_C   = YES
 ENABLE_PREPROCESSING    = YES
 MACRO_EXPANSION         = YES

--- a/doc/gen-man-pages.sh
+++ b/doc/gen-man-pages.sh
@@ -31,17 +31,20 @@ fi
 for xml in $groups; do
 	doxygen2man -m -p libecoli -s 3 \
 		-H "Libecoli Programmer's Manual" \
-		-C "Olivier Matz" \
+		-C "Olivier Matz, Robin Jarry" \
 		-S "2010" \
 		-d "$xml_dir" \
 		-o "$output_dir" \
-		"$xml"
+		"$xml" || [ "$?" -gt 128 ]
 done
 
 # Fix include paths in generated man pages.
 xpath='string(//memberdef[@kind="function"][name="%s"]/location/@file)'
 for manpage in "$output_dir"/*.3; do
-	[ -f "$manpage" ] || continue
+	if ! [ -s "$manpage" ]; then
+		rm -f "$manpage"
+		continue
+	fi
 	func_name=$(basename -s .3 "$manpage")
 	inc=$(xmllint --xpath "$(printf "$xpath" "$func_name")" \
 		"$xml_dir"/group__*.xml 2>/dev/null | xargs echo)
@@ -51,6 +54,10 @@ for manpage in "$output_dir"/*.3; do
 done
 
 # Strip the systematic ", Inc. All rights reserved." suffix to all copyrights
-sed -i 's/, Inc\. All rights reserved\.//' "$output_dir"/*.3
+sed -Ei 's/, Inc\. All rights reserved//' "$output_dir"/*.3
+# Strip empty DESCRIPTION sections
+sed -Ezi 's/\.SH DESCRIPTION\n\.(SH|RE)/.\1/' "$output_dir"/*.3
+# Trim trailing whitespace
+sed -Ei 's/[[:space:]]+$//' "$output_dir"/*.3
 
 touch "$stamp"


### PR DESCRIPTION
This allows doxygen2man to generate proper NAME sections, with the symbol name and short description.