### PR TITLE
docs: use SOURCE_DATE_EPOCH for man page dates

### DIFF
--- a/doc/gen-man-pages.sh
+++ b/doc/gen-man-pages.sh
@@ -35,6 +35,7 @@ for xml in $groups; do
 		-S "2010" \
 		-d "$xml_dir" \
 		-o "$output_dir" \
+		-D "$(date +%Y-%m-%d ${SOURCE_DATE_EPOCH:+-d @${SOURCE_DATE_EPOCH}})" \
 		"$xml" || [ "$?" -gt 128 ]
 done
 


### PR DESCRIPTION
If SOURCE_DATE_EPOCH is set, use that instead of the current date for man pages; this ensures that they can be reproduced.

This fixes the [reproducibility issue in Debian](https://reproduce.debian.net/excuses.html?source_name=libecoli).